### PR TITLE
feat: add booking management pages for customer-side

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,14 +4,14 @@ const Footer = () => {
   return (
     <footer
       className="w-full bg-[#384B3F] text-white"
-      style={{ maxWidth: "1440px", margin: "0 auto" }}
+      style={{ margin: "0 auto" }}
     >
       <div
         className="
           flex flex-col md:flex-row
           justify-between
           items-start
-          max-w-[1440px] mx-auto
+          mx-auto
           px-6 md:px-12
           pt-12
           pb-8
@@ -53,7 +53,9 @@ const Footer = () => {
                   style={{ minWidth: 24, minHeight: 24 }}
                 />
               </span>
-              <span className="font-normal text-[#ffffff] text-left">+66 99 999 9999</span>
+              <span className="font-normal text-[#ffffff] text-left">
+                +66 99 999 9999
+              </span>
             </div>
             <div className="flex items-center gap-3 text-base text-[#ffffff] justify-start">
               <span className="inline-block text-[#ffffff]">
@@ -65,7 +67,9 @@ const Footer = () => {
                   style={{ minWidth: 24, minHeight: 24 }}
                 />
               </span>
-              <span className="font-normal text-[#ffffff] text-left">contact@neatlyhotel.com</span>
+              <span className="font-normal text-[#ffffff] text-left">
+                contact@neatlyhotel.com
+              </span>
             </div>
             <div className="flex items-start gap-3 text-base text-[#ffffff] justify-start">
               <span className="inline-block pt-0.5 text-[#ffffff]">
@@ -78,7 +82,8 @@ const Footer = () => {
                 />
               </span>
               <span className="font-normal text-[#ffffff] leading-snug text-left">
-                188 Phaya Thai Rd, Thung Phaya Thai,<br />
+                188 Phaya Thai Rd, Thung Phaya Thai,
+                <br />
                 Ratchathewi, Bangkok 10400
               </span>
             </div>
@@ -93,7 +98,12 @@ const Footer = () => {
         <div className="flex flex-row items-center justify-between w-full md:w-auto">
           <div className="flex items-center space-x-4">
             {/* Social icons */}
-            <a href="https://www.facebook.com/" aria-label="Facebook" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://www.facebook.com/"
+              aria-label="Facebook"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <Image
                 src="/icons/facebook.png"
                 alt="Facebook"
@@ -102,7 +112,12 @@ const Footer = () => {
                 style={{ minWidth: 18, minHeight: 18 }}
               />
             </a>
-            <a href="https://www.instagram.com/" aria-label="Instagram" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://www.instagram.com/"
+              aria-label="Instagram"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <Image
                 src="/icons/instagram.png"
                 alt="Instagram"
@@ -111,7 +126,12 @@ const Footer = () => {
                 style={{ minWidth: 18, minHeight: 18 }}
               />
             </a>
-            <a href="https://x.com/" aria-label="Twitter" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://x.com/"
+              aria-label="Twitter"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <Image
                 src="/icons/twitter.png"
                 alt="Twitter"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -20,7 +20,7 @@ export default function Layout({ children }: LayoutProps) {
         }}
       />
       <Navbar />
-      <main className="flex-grow">{children}</main>
+      <main className="flex-grow bg-[#F7F7FB]">{children}</main>
       <Footer />
     </div>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import Navbar from "@/components/Navbar";
 import Footer from "./Footer";
+import { Toaster } from "sonner";
 
 export type LayoutProps = {
   children?: React.ReactNode;
@@ -8,6 +9,16 @@ export type LayoutProps = {
 export default function Layout({ children }: LayoutProps) {
   return (
     <div>
+      <Toaster
+        position="top-right"
+        richColors
+        expand={true}
+        toastOptions={{
+          style: {
+            zIndex: 9999,
+          },
+        }}
+      />
       <Navbar />
       {children}
       <Footer />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,14 +1,16 @@
 import Navbar from "@/components/Navbar";
+import Footer from "./Footer";
 
- export type LayoutProps = {
+export type LayoutProps = {
   children?: React.ReactNode;
 };
 
 export default function Layout({ children }: LayoutProps) {
   return (
     <div>
-      <Navbar/>
+      <Navbar />
       {children}
+      <Footer />
     </div>
-  )
+  );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,7 +8,7 @@ export type LayoutProps = {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <div>
+    <div className="flex flex-col min-h-screen">
       <Toaster
         position="top-right"
         richColors
@@ -20,7 +20,7 @@ export default function Layout({ children }: LayoutProps) {
         }}
       />
       <Navbar />
-      {children}
+      <main className="flex-grow">{children}</main>
       <Footer />
     </div>
   );

--- a/src/components/admin/ui/ConfirmModal.tsx
+++ b/src/components/admin/ui/ConfirmModal.tsx
@@ -1,27 +1,49 @@
 import { useEffect, useRef } from "react";
 
 type ConfirmModalProps = {
+  /** Controls visibility of the modal */
   open: boolean;
+
+  /** Optional: Title text at the top */
   title?: string;
-  message?: string;
+
+  /** Optional: Description or message */
+  message?: string | React.ReactNode;
+
+  /** Optional: Text for confirm button */
   confirmText?: string;
+
+  /** Optional: Text for cancel button */
   cancelText?: string;
-  onConfirm: (e: React.FormEvent) => void;
+
+  /** Optional: Custom styling for confirm button (e.g. color) */
+  confirmButtonClassName?: string;
+
+  /** Optional: Custom styling for cancel button */
+  cancelButtonClassName?: string;
+
+  /** Handler when user confirms */
+  onConfirm: () => void;
+
+  /** Handler when user closes modal (either X or backdrop or cancel) */
   onClose: () => void;
 };
 
 export default function ConfirmModal({
   open,
-  title = "Cancel Booking",
-  message = "Are you sure you would like to cancel this booking?",
-  confirmText = "Yes, I want to cancel and request refund",
-  cancelText = "No, Don’t Cancel",
+  title = "Confirm Action",
+  message = "Are you sure you want to continue?",
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  confirmButtonClassName = "border border-orange-500 text-orange-500 hover:bg-orange-50",
+  cancelButtonClassName = "bg-orange-600 text-white hover:brightness-110",
   onConfirm,
   onClose,
 }: ConfirmModalProps) {
   const backdropRef = useRef<HTMLDivElement | null>(null);
   const confirmBtnRef = useRef<HTMLButtonElement | null>(null);
 
+  // Handle Escape key + focus
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
@@ -53,58 +75,40 @@ export default function ConfirmModal({
         <div className="flex items-center justify-between border-b border-gray-200 px-6 py-3">
           <h2
             id="confirm-modal-title"
-            className="font-inter font-semibold text-[20px] leading-[150%] tracking-[-2%] text-black"
+            className="font-inter font-semibold text-[20px] text-black"
           >
             {title}
           </h2>
 
-          {/* Close button */}
           <button
             type="button"
             aria-label="Close"
             onClick={onClose}
-            className="cursor-pointer grid h-10 w-10 place-items-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+            className="grid h-10 w-10 place-items-center rounded-md text-gray-500 hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-orange-400"
           >
-            <span className="text-[20px] leading-none">×</span>
+            ×
           </button>
         </div>
 
         {/* Body */}
         <div className="px-6 py-6">
-          <p className="text-[16px] font-inter leading-[150%] tracking-[-2%] text-gray-900">
+          <p className="text-[16px] font-inter leading-[150%] text-gray-900">
             {message}
           </p>
 
-          {/* Buttons row */}
+          {/* Buttons */}
           <div className="mt-6 flex justify-end gap-4">
             <button
               ref={confirmBtnRef}
-              type="button"
               onClick={onConfirm}
-              className="
-                inline-flex h-12 items-center justify-center
-                rounded-md border border-orange-500
-                px-6 text-[16px] font-semibold text-orange-500
-                hover:bg-orange-50 font-inter
-                focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400
-                cursor-pointer
-              "
+              className={`inline-flex h-12 items-center justify-center rounded-md px-6 text-[16px] font-semibold focus-visible:ring-2 focus-visible:ring-orange-400 ${confirmButtonClassName}`}
             >
               {confirmText}
             </button>
 
             <button
-              type="button"
               onClick={onClose}
-              className="
-                inline-flex h-12 items-center justify-center
-                rounded-md bg-orange-600 px-6
-                text-[16px] font-semibold text-white
-                hover:brightness-110
-                focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400
-                min-w-[200px]
-                cursor-pointer
-              "
+              className={`inline-flex h-12 items-center justify-center rounded-md px-6 text-[16px] font-semibold focus-visible:ring-2 focus-visible:ring-orange-400 ${cancelButtonClassName}`}
             >
               {cancelText}
             </button>

--- a/src/components/booking-history/BookingCard.tsx
+++ b/src/components/booking-history/BookingCard.tsx
@@ -361,12 +361,18 @@ export default function BookingCard({ booking, onDeleted }: Props) {
               >
                 Room Detail
               </Link>
-              <button
-                type="button"
-                className="inline-flex h-11 w-full items-center justify-center rounded-md bg-orange-600 font-semibold font-inter px-4 text-[16px] text-white hover:brightness-110"
+
+              <Link
+                href={`/customer/customer-bookings/change/${booking.id}`}
+                passHref
               >
-                Change Date
-              </button>
+                <button
+                  type="button"
+                  className="inline-flex h-11 w-full items-center justify-center rounded-md bg-orange-600 font-semibold font-inter px-4 text-[16px] text-white hover:brightness-110"
+                >
+                  Change Date
+                </button>
+              </Link>
             </div>
 
             <div className="mt-3 flex w-full justify-end">
@@ -403,12 +409,18 @@ export default function BookingCard({ booking, onDeleted }: Props) {
               >
                 Room Detail
               </Link>
-              <button
-                type="button"
-                className="rounded-md bg-orange-600 text-white px-5 py-2 text-[16px] font-semibold font-inter cursor-pointer hover:brightness-110"
+
+              <Link
+                href={`/customer/customer-bookings/change/${booking.id}`}
+                passHref
               >
-                Change Date
-              </button>
+                <button
+                  type="button"
+                  className="rounded-md bg-orange-600 text-white px-5 py-2 text-[16px] font-semibold font-inter cursor-pointer hover:brightness-110"
+                >
+                  Change Date
+                </button>
+              </Link>
             </div>
           </div>
         </div>

--- a/src/components/booking-history/BookingCard.tsx
+++ b/src/components/booking-history/BookingCard.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import NonRefundModal from "@/components/ui/NonRefundModal";
 import { supabase } from "@/lib/supabaseClient";
+import { useRouter } from "next/router";
 
 /** ---- Types ---- */
 export type Booking = {
@@ -92,6 +93,7 @@ type PostgrestErrorLite = {
 };
 
 export default function BookingCard({ booking, onDeleted }: Props) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [showRefundModal, setShowRefundModal] = useState(false);
   const [showNonRefundModal, setShowNonRefundModal] = useState(false);
@@ -378,7 +380,11 @@ export default function BookingCard({ booking, onDeleted }: Props) {
             <div className="mt-3 flex w-full justify-end">
               <button
                 type="button"
-                onClick={handleCancelClick}
+                onClick={() =>
+                  router.push(
+                    `/customer/customer-bookings/cancel/${booking.id}`
+                  )
+                }
                 disabled={deleting}
                 className={`text-[16px] font-inter font-semibold text-orange-500 hover:underline ${
                   deleting ? "opacity-60 cursor-not-allowed" : "cursor-pointer"

--- a/src/components/booking/ChangeDateForm.tsx
+++ b/src/components/booking/ChangeDateForm.tsx
@@ -6,6 +6,7 @@ interface ChangeDateFormProps {
   onClick: (e: React.MouseEvent) => void;
   onSubmit: (e: React.FormEvent) => void;
   onCancel: () => void;
+  minDate?: string; // Added minDate prop
 }
 
 export default function ChangeDateForm({
@@ -16,13 +17,13 @@ export default function ChangeDateForm({
   onClick,
   onSubmit,
   onCancel,
+  minDate, // Added minDate parameter
 }: ChangeDateFormProps) {
   return (
     <>
       {/* Change Date Form */}
       <form onSubmit={onSubmit} className="bg-white px-5 pt-5 pb-2 rounded-lg">
         <p className="text-lg font-bold text-gray-800 mb-4">Change Date</p>
-
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
           {/* Check In */}
           <div>
@@ -32,12 +33,12 @@ export default function ChangeDateForm({
                 type="date"
                 value={checkIn}
                 onChange={(e) => onCheckInChange(e.target.value)}
+                min={minDate} // Added min attribute
                 className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
                 required
               />
             </div>
           </div>
-
           {/* Check Out */}
           <div>
             <label className="block text-lg text-gray-800 mb-2">
@@ -48,6 +49,7 @@ export default function ChangeDateForm({
                 type="date"
                 value={checkOut}
                 onChange={(e) => onCheckOutChange(e.target.value)}
+                min={minDate} // Added min attribute
                 className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
                 required
               />
@@ -55,7 +57,6 @@ export default function ChangeDateForm({
           </div>
         </div>
       </form>
-
       {/* Confirm Change Date Button */}
       <div className="flex justify-end mt-10">
         <button
@@ -66,7 +67,6 @@ export default function ChangeDateForm({
           Confirm Change Date
         </button>
       </div>
-
       {/* Mobile Cancel Button */}
       <div className="flex h-full justify-center items-center mt-3">
         <button

--- a/src/components/booking/ChangeDateForm.tsx
+++ b/src/components/booking/ChangeDateForm.tsx
@@ -1,0 +1,82 @@
+interface ChangeDateFormProps {
+  checkIn: string;
+  checkOut: string;
+  onCheckInChange: (value: string) => void;
+  onCheckOutChange: (value: string) => void;
+  onClick: (e: React.MouseEvent) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onCancel: () => void;
+}
+
+export default function ChangeDateForm({
+  checkIn,
+  checkOut,
+  onCheckInChange,
+  onCheckOutChange,
+  onClick,
+  onSubmit,
+  onCancel,
+}: ChangeDateFormProps) {
+  return (
+    <>
+      {/* Change Date Form */}
+      <form onSubmit={onSubmit} className="bg-white px-5 pt-5 pb-2 rounded-lg">
+        <p className="text-lg font-bold text-gray-800 mb-4">Change Date</p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+          {/* Check In */}
+          <div>
+            <label className="block text-lg text-gray-800 mb-2">Check In</label>
+            <div className="relative">
+              <input
+                type="date"
+                value={checkIn}
+                onChange={(e) => onCheckInChange(e.target.value)}
+                className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                required
+              />
+            </div>
+          </div>
+
+          {/* Check Out */}
+          <div>
+            <label className="block text-lg text-gray-800 mb-2">
+              Check Out
+            </label>
+            <div className="relative">
+              <input
+                type="date"
+                value={checkOut}
+                onChange={(e) => onCheckOutChange(e.target.value)}
+                className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                required
+              />
+            </div>
+          </div>
+        </div>
+      </form>
+
+      {/* Confirm Change Date Button */}
+      <div className="flex justify-end mt-10">
+        <button
+          type="submit"
+          onClick={onClick}
+          className="flex-1 md:flex-none px-8 py-3 bg-orange-600 hover:bg-orange-700 text-white font-medium rounded-md transition-colors cursor-pointer"
+        >
+          Confirm Change Date
+        </button>
+      </div>
+
+      {/* Mobile Cancel Button */}
+      <div className="flex h-full justify-center items-center mt-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="md:hidden px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
+        >
+          Cancel
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/booking/OriginalBookingDetail.tsx
+++ b/src/components/booking/OriginalBookingDetail.tsx
@@ -1,0 +1,39 @@
+import { formatDate } from "@/utils/formatDate";
+
+interface OriginalBookingDetailProps {
+  roomType?: string;
+  bookingDate?: string;
+  checkInDate: string;
+  checkOutDate: string;
+}
+
+export default function OriginalBookingDetail({
+  roomType,
+  bookingDate,
+  checkInDate,
+  checkOutDate,
+}: OriginalBookingDetailProps) {
+  return (
+    <div className="md:w-full p-5 md:p-0 md:pl-15">
+      {/* Room Type and Booking Date Header */}
+      <div className="flex flex-col md:flex-row justify-between items-start mb-6">
+        <h2 className="text-3xl md:text-4xl font-bold text-black font-inter mt-2">
+          {roomType || "Room"}
+        </h2>
+        <p className="text-md text-gray-600">
+          Booking date: {bookingDate ? formatDate(bookingDate) : "N/A"}
+        </p>
+      </div>
+
+      {/* Original Dates */}
+      <div className="mb-8">
+        <p className="text-lg font-semibold text-gray-800 mb-2">
+          Original Date
+        </p>
+        <p className="text-gray-700 text-md">
+          {formatDate(checkInDate)} - {formatDate(checkOutDate)}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/booking/changeDateForm.tsx
+++ b/src/components/booking/changeDateForm.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const changeDateForm = () => {
+  return <div>changeDateForm</div>;
+};
+
+export default changeDateForm;

--- a/src/components/booking/changeDateForm.tsx
+++ b/src/components/booking/changeDateForm.tsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const changeDateForm = () => {
-  return <div>changeDateForm</div>;
-};
-
-export default changeDateForm;

--- a/src/components/ui/ConfirmModal.tsx
+++ b/src/components/ui/ConfirmModal.tsx
@@ -76,7 +76,7 @@ export default function ConfirmModal({
           </p>
 
           {/* Buttons row */}
-          <div className="mt-6 flex justify-end gap-4">
+          <div className="mt-6 flex justify-end flex-col md:flex-row gap-4">
             <button
               ref={confirmBtnRef}
               type="button"

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,26 +1,31 @@
 import { useEffect, useState } from "react";
 
-export const useQuery = <T>(url: string) => {
+export function useQuery<T>(url: string) {
   const [data, setData] = useState<T | null>(null);
-  const [error, setError] = useState<Error | undefined>(undefined);
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch(url);
-        const data = await response.json();
-        console.log("Data:", data);
-        setData(data);
-      } catch (err) {
-        setError(err as Error);
-      } finally {
-        setLoading(false);
-      }
-    };
+    // Skip fetch if url is empty
+    if (!url) {
+      setLoading(false);
+      return;
+    }
 
-    fetchData();
+    setLoading(true);
+    setError(null);
+
+    fetch(url)
+      .then((res) => res.json())
+      .then((data) => {
+        setData(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err);
+        setLoading(false);
+      });
   }, [url]);
 
-  return { data, error, loading };
-};
+  return { data, loading, error };
+}

--- a/src/pages/admin/bookings/[id].tsx
+++ b/src/pages/admin/bookings/[id].tsx
@@ -1,46 +1,46 @@
-import Layout from "@/components/admin/Layout"
-import { ArrowLeft } from "lucide-react"
-import { useRouter } from "next/router"
-import { useEffect, useState, useMemo } from "react"
-import type { Booking } from "@/types/bookings"
+import Layout from "@/components/admin/Layout";
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/router";
+import { useEffect, useState, useMemo } from "react";
+import type { Booking } from "@/types/bookings";
 
 export default function BookingDetailPage() {
-  const router = useRouter()
-  const { id } = router.query
+  const router = useRouter();
+  const { id } = router.query;
 
-  const [booking, setBooking] = useState<Booking | null>(null)
-  const [loading, setLoading] = useState<boolean>(true)
-  const [error, setError] = useState<string | null>(null)
+  const [booking, setBooking] = useState<Booking | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!id) return
+    if (!id) return;
     const fetchBooking = async () => {
       try {
-        const res = await fetch(`/api/bookings/${id}`)
-        const body = await res.json()
+        const res = await fetch(`/api/bookings/${id}`);
+        const body = await res.json();
         if (body?.success) {
-          setBooking(body.data)
+          setBooking(body.data);
         } else {
-          setError(body?.error || "Failed to load booking")
+          setError(body?.error || "Failed to load booking");
         }
       } catch (e) {
-        setError("Failed to load booking")
+        setError("Failed to load booking");
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
-    }
-    fetchBooking()
-  }, [id])
+    };
+    fetchBooking();
+  }, [id]);
 
   const priceDisplay = useMemo(() => {
-    if (!booking) return "-"
-    const promotion = booking.promotion_price ?? undefined
-    const price = booking.price ?? undefined
+    if (!booking) return "-";
+    const promotion = booking.promotion_price ?? undefined;
+    const price = booking.price ?? undefined;
     if (promotion && promotion > 0 && promotion < (price ?? 0)) {
-      return `THB ${promotion.toLocaleString()} (was THB ${price?.toLocaleString?.()})`
+      return `THB ${promotion.toLocaleString()} (was THB ${price?.toLocaleString?.()})`;
     }
-    return price ? `THB ${price.toLocaleString()}` : "-"
-  }, [booking])
+    return price ? `THB ${price.toLocaleString()}` : "-";
+  }, [booking]);
 
   return (
     <Layout>
@@ -52,16 +52,20 @@ export default function BookingDetailPage() {
               className="w-5 mt-1 cursor-pointer"
               onClick={() => router.push("/admin/bookings")}
             />
-            <span className="text-gray-900 font-medium truncate max-w-[30ch]">{
-              booking
-                ? (booking.customer_name
-                  || booking.full_name
-                  || [booking.first_name, booking.last_name].filter(Boolean).join(" ")
-                  || booking.username
-                  || "-")
-                : "-"
-            }</span>
-            <span className="text-gray-500 truncate max-w-[40ch]">{booking?.room_type || "-"}</span>
+            <span className="text-gray-900 font-medium truncate max-w-[30ch]">
+              {booking
+                ? booking.customer_name ||
+                  booking.full_name ||
+                  [booking.first_name, booking.last_name]
+                    .filter(Boolean)
+                    .join(" ") ||
+                  booking.username ||
+                  "-"
+                : "-"}
+            </span>
+            <span className="text-gray-500 truncate max-w-[40ch]">
+              {booking?.room_type || "-"}
+            </span>
           </div>
         </div>
 
@@ -80,20 +84,71 @@ export default function BookingDetailPage() {
                     <InfoItem
                       label="Customer name"
                       value={
-                        booking.customer_name
-                          || booking.full_name
-                          || [booking.first_name, booking.last_name].filter(Boolean).join(" ")
-                          || (booking.username ?? "-")
+                        booking.customer_name ||
+                        booking.full_name ||
+                        [booking.first_name, booking.last_name]
+                          .filter(Boolean)
+                          .join(" ") ||
+                        (booking.username ?? "-")
                       }
                     />
                     <InfoItem label="Guest(s)" value={booking.guests ?? "-"} />
-                    <InfoItem label="Room type" value={booking.room_type || "-"} />
-                    <InfoItem label="Amount" value={(booking.amount ?? 1) + " room"} />
-                    <InfoItem label="Bed type" value={booking.bed_type ?? "-"} />
-                    <InfoItem label="Check-in" value={(booking.check_in_date || booking.check_in) ? new Date((booking.check_in_date || booking.check_in) as string).toLocaleDateString("en-GB", { weekday: "short", day: "2-digit", month: "short", year: "numeric" }) : "-"} />
-                    <InfoItem label="Check-out" value={(booking.check_out_date || booking.check_out) ? new Date((booking.check_out_date || booking.check_out) as string).toLocaleDateString("en-GB", { weekday: "short", day: "2-digit", month: "short", year: "numeric" }) : "-"} />
-                    <InfoItem label="Stay (total)" value={booking.stay_total_nights ?? "-"} />
-                    <InfoItem label="Booking date" value={booking.created_at ? new Date(booking.created_at).toDateString() : "-"} />
+                    <InfoItem
+                      label="Room type"
+                      value={booking.room_type || "-"}
+                    />
+                    <InfoItem
+                      label="Amount"
+                      value={(booking.amount ?? 1) + " room"}
+                    />
+                    <InfoItem
+                      label="Bed type"
+                      value={booking.bed_type ?? "-"}
+                    />
+                    <InfoItem
+                      label="Check-in"
+                      value={
+                        booking.check_in_date || booking.check_in
+                          ? new Date(
+                              (booking.check_in_date ||
+                                booking.check_in) as string
+                            ).toLocaleDateString("en-GB", {
+                              weekday: "short",
+                              day: "2-digit",
+                              month: "short",
+                              year: "numeric",
+                            })
+                          : "-"
+                      }
+                    />
+                    <InfoItem
+                      label="Check-out"
+                      value={
+                        booking.check_out_date || booking.check_out
+                          ? new Date(
+                              (booking.check_out_date ||
+                                booking.check_out) as string
+                            ).toLocaleDateString("en-GB", {
+                              weekday: "short",
+                              day: "2-digit",
+                              month: "short",
+                              year: "numeric",
+                            })
+                          : "-"
+                      }
+                    />
+                    <InfoItem
+                      label="Stay (total)"
+                      value={booking.stay_total_nights ?? "-"}
+                    />
+                    <InfoItem
+                      label="Booking date"
+                      value={
+                        booking.created_at
+                          ? new Date(booking.created_at).toDateString()
+                          : "-"
+                      }
+                    />
                   </div>
                 </div>
 
@@ -106,7 +161,9 @@ export default function BookingDetailPage() {
                   <div className="p-0">
                     <div className="px-4 py-3 text-sm text-gray-700 flex items-center justify-between border-b border-gray-100">
                       <span>{booking.room_type || "Room"}</span>
-                      <span>{booking.price ? booking.price.toLocaleString() : "-"}</span>
+                      <span>
+                        {booking.price ? booking.price.toLocaleString() : "-"}
+                      </span>
                     </div>
                     <div className="px-4 py-3 text-sm text-gray-700 flex items-center justify-between border-b border-gray-100">
                       <span>Airport transfer</span>
@@ -114,7 +171,18 @@ export default function BookingDetailPage() {
                     </div>
                     <div className="px-4 py-3 text-sm text-gray-700 flex items-center justify-between border-b border-gray-100">
                       <span>Promotion Code</span>
-                      <span className="text-red-600">{booking.promotion_price ? `-${(booking.price && booking.promotion_price < booking.price) ? (booking.price - booking.promotion_price).toLocaleString() : 0}` : "-0"}</span>
+                      <span className="text-red-600">
+                        {booking.promotion_price
+                          ? `-${
+                              booking.price &&
+                              booking.promotion_price < booking.price
+                                ? (
+                                    booking.price - booking.promotion_price
+                                  ).toLocaleString()
+                                : 0
+                            }`
+                          : "-0"}
+                      </span>
                     </div>
                     <div className="px-4 py-3 text-sm text-gray-900 font-medium flex items-center justify-between">
                       <span>Total</span>
@@ -125,7 +193,9 @@ export default function BookingDetailPage() {
 
                 {/* Additional Request (full width, below) */}
                 <div className="mt-6 overflow-hidden rounded-md border border-gray-200">
-                  <div className="bg-gray-50 px-4 py-2 text-sm text-gray-600">Additional Request</div>
+                  <div className="bg-gray-50 px-4 py-2 text-sm text-gray-600">
+                    Additional Request
+                  </div>
                   <div className="px-4 py-3 text-sm text-gray-700">-</div>
                 </div>
               </>
@@ -134,7 +204,7 @@ export default function BookingDetailPage() {
         </div>
       </main>
     </Layout>
-  )
+  );
 }
 
 function InfoItem({ label, value }: { label: string; value: string | number }) {
@@ -143,7 +213,5 @@ function InfoItem({ label, value }: { label: string; value: string | number }) {
       <div className="text-sm font-medium text-gray-500">{label}</div>
       <div className="mt-1 text-gray-800">{value}</div>
     </div>
-  )
+  );
 }
-
-

--- a/src/pages/api/bookings/[id].ts
+++ b/src/pages/api/bookings/[id].ts
@@ -108,36 +108,64 @@ export default async function handler(
     }
 
     if (req.method === "PUT") {
-      let { check_in_date, check_out_date } = req.body;
+      const { check_in_date, check_out_date, status, cancellation_date } =
+        req.body;
 
-      if (!check_in_date || !check_out_date) {
-        return res.status(400).json({
-          success: false,
-          message: "Check-in and Check-out dates are required",
-        });
+      // Build the update object dynamically
+      const updateData: {
+        check_in_date?: string;
+        check_out_date?: string;
+        status?: string;
+        cancellation_date?: string;
+      } = {};
+
+      // Handle date changes (for change booking page)
+      if (check_in_date && check_out_date) {
+        try {
+          updateData.check_in_date = new Date(check_in_date).toISOString();
+          updateData.check_out_date = new Date(check_out_date).toISOString();
+        } catch (e) {
+          return res.status(400).json({
+            success: false,
+            message: "Invalid date format",
+            error: e instanceof Error ? e.message : "Invalid date",
+          });
+        }
       }
 
-      // Convert date strings to ISO 8601 for timestamptz
-      try {
-        check_in_date = new Date(check_in_date).toISOString();
-        check_out_date = new Date(check_out_date).toISOString();
-      } catch (e) {
+      // Handle cancellation (for cancel booking page)
+      if (status) {
+        updateData.status = status;
+      }
+
+      if (cancellation_date) {
+        try {
+          updateData.cancellation_date = new Date(
+            cancellation_date
+          ).toISOString();
+        } catch (e) {
+          return res.status(400).json({
+            success: false,
+            message: "Invalid cancellation date format",
+            error: e instanceof Error ? e.message : "Invalid date",
+          });
+        }
+      }
+
+      // Check if there's anything to update
+      if (Object.keys(updateData).length === 0) {
         return res.status(400).json({
           success: false,
-          message: "Invalid date format",
-          error: e instanceof Error ? e.message : "Invalid date",
+          message: "No valid fields provided to update",
         });
       }
 
       // Update booking
-
       const { data, error } = await supabase
         .from("bookings")
-        .update({ check_in_date, check_out_date })
+        .update(updateData)
         .eq("id", id)
         .select();
-
-      // console.log("Booking Data", data);
 
       if (error) {
         return res.status(400).json({
@@ -161,10 +189,28 @@ export default async function handler(
       });
     }
 
+    // 🗑️ DELETE booking by ID
+    if (req.method === "DELETE") {
+      const { error } = await supabase.from("bookings").delete().eq("id", id);
+
+      if (error) {
+        return res.status(400).json({
+          success: false,
+          message: "Failed to delete booking",
+          error: error.message,
+        });
+      }
+
+      return res.status(200).json({
+        success: true,
+        message: "Booking deleted successfully",
+      });
+    }
+
     // Method not allowed
     return res.status(405).json({
       success: false,
-      message: "Method not allowed. Use GET or PUT.",
+      message: "Method not allowed. Use GET, PUT, or DELETE.",
     });
   } catch (err) {
     return res.status(500).json({

--- a/src/pages/api/bookings/[id].ts
+++ b/src/pages/api/bookings/[id].ts
@@ -1,9 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createClient } from "@supabase/supabase-js";
 
+// Initialize Supabase client
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
 
 type Data = {
@@ -18,7 +19,6 @@ type Profile = {
   first_name?: string | null;
   last_name?: string | null;
   username?: string | null;
-  full_name?: string | null;
 };
 
 type BookingRow = {
@@ -31,6 +31,8 @@ type BookingRow = {
   room_type?: string | null;
   bed_type?: string | null;
   main_image_url?: string[] | null;
+  check_in_date?: string | null;
+  check_out_date?: string | null;
   rooms?: {
     guests?: number | null;
     room_type?: string | null;
@@ -41,13 +43,22 @@ type BookingRow = {
   [key: string]: unknown;
 };
 
+// Helper to synthesize customer name
+function getCustomerName(data: BookingRow) {
+  const profile = data.profiles;
+  return (
+    [profile?.first_name, profile?.last_name].filter(Boolean).join(" ") ||
+    profile?.username ||
+    null
+  );
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Data>
 ) {
   const { id } = req.query as { id?: string };
 
-  // ✅ 1. Validate ID
   if (!id) {
     return res.status(400).json({
       success: false,
@@ -56,117 +67,110 @@ export default async function handler(
     });
   }
 
-  // ✅ 2. Only allow GET
-  if (req.method !== "GET") {
-    return res.status(405).json({
-      success: false,
-      message: "Method not allowed. Use GET.",
-    });
-  }
-
   try {
-    // ✅ 3. Try main query (bookings + rooms + profiles)
-    const result = await supabase
-      .from("bookings")
-      .select(
-        `
-        *,
-        rooms(guests, room_type, bed_type, main_image_url),
-        profiles(first_name, last_name, username, full_name)
-      `
-      )
-      .eq("id", id)
-      .single();
-
-    let data = result.data as BookingRow | null;
-    const error = result.error;
-
-    // ✅ 4. Fallback if join fails
-    if (error) {
-      const fallback = await supabase
+    if (req.method === "GET") {
+      // Fetch booking
+      const { data, error } = await supabase
         .from("bookings")
         .select(
           `
           *,
-          rooms(guests, room_type, bed_type, main_image_url)
+          rooms(guests, room_type, bed_type, main_image_url),
+          profiles(first_name, last_name, username)
         `
         )
         .eq("id", id)
         .single();
 
-      if (fallback.error) {
-        return res.status(400).json({
+      if (error || !data) {
+        return res.status(404).json({
           success: false,
-          message: "Failed to fetch booking",
-          error: fallback.error.message,
+          message: "Booking not found",
+          error: error?.message ?? "No data",
         });
       }
-      data = fallback.data as BookingRow;
-    }
 
-    if (!data) {
-      return res.status(404).json({
-        success: false,
-        message: "Booking not found",
+      const enriched: BookingRow = {
+        ...data,
+        customer_name: getCustomerName(data),
+        guests: data.rooms?.guests ?? data.guests ?? null,
+        room_type: data.rooms?.room_type ?? data.room_type ?? null,
+        bed_type: data.rooms?.bed_type ?? data.bed_type ?? null,
+        main_image_url:
+          data.rooms?.main_image_url ?? data.main_image_url ?? null,
+      };
+
+      return res.status(200).json({
+        success: true,
+        message: "Booking fetched successfully",
+        data: enriched,
       });
     }
 
-    // ✅ 5. Enrich / synthesize data
-    const profile = data.profiles;
-    const synthesizedName =
-      data.customer_name ||
-      profile?.full_name ||
-      [profile?.first_name, profile?.last_name].filter(Boolean).join(" ") ||
-      profile?.username ||
-      null;
+    if (req.method === "PUT") {
+      let { check_in_date, check_out_date } = req.body;
 
-    let enriched: BookingRow = {
-      ...data,
-      customer_name: synthesizedName,
-      guests: data.rooms?.guests ?? data.guests ?? null,
-      room_type: data.rooms?.room_type ?? data.room_type ?? null,
-      bed_type: data.rooms?.bed_type ?? data.bed_type ?? null,
-      main_image_url: data.rooms?.main_image_url ?? data.main_image_url ?? null,
-    };
-
-    // ✅ 6. If still missing name → fetch from profiles table
-    if (
-      !enriched.customer_name &&
-      (enriched.customer_id || enriched.user_id || enriched.profile_id)
-    ) {
-      const profileId =
-        enriched.customer_id || enriched.user_id || enriched.profile_id;
-
-      const { data: profileData, error: profileError } = await supabase
-        .from("profiles")
-        .select("id, first_name, last_name, username, full_name")
-        .eq("id", profileId)
-        .single();
-
-      if (!profileError && profileData) {
-        const synthesized =
-          profileData.full_name ||
-          [profileData.first_name, profileData.last_name]
-            .filter(Boolean)
-            .join(" ") ||
-          profileData.username ||
-          null;
-
-        enriched = { ...enriched, customer_name: synthesized };
+      if (!check_in_date || !check_out_date) {
+        return res.status(400).json({
+          success: false,
+          message: "Check-in and Check-out dates are required",
+        });
       }
+
+      // Convert date strings to ISO 8601 for timestamptz
+      try {
+        check_in_date = new Date(check_in_date).toISOString();
+        check_out_date = new Date(check_out_date).toISOString();
+      } catch (e) {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid date format",
+          error: e instanceof Error ? e.message : "Invalid date",
+        });
+      }
+
+      // Update booking
+
+      const { data, error } = await supabase
+        .from("bookings")
+        .update({ check_in_date, check_out_date })
+        .eq("id", id)
+        .select();
+
+      // console.log("Booking Data", data);
+
+      if (error) {
+        return res.status(400).json({
+          success: false,
+          message: "Failed to update booking",
+          error: error.message,
+        });
+      }
+
+      if (!data || data.length === 0) {
+        return res.status(404).json({
+          success: false,
+          message: "Booking not found",
+        });
+      }
+
+      return res.status(200).json({
+        success: true,
+        message: "Booking updated successfully",
+        data: data[0],
+      });
     }
 
-    // ✅ 7. Send success response
-    return res.status(200).json({
-      success: true,
-      message: "Booking fetched successfully",
-      data: enriched,
+    // Method not allowed
+    return res.status(405).json({
+      success: false,
+      message: "Method not allowed. Use GET or PUT.",
     });
-  } catch (error) {
+  } catch (err) {
     return res.status(500).json({
       success: false,
       message: "Server error",
-      error: error instanceof Error ? error.message : "Unknown error",
+      error: err instanceof Error ? err.message : "Unknown error",
     });
   }
 }

--- a/src/pages/api/bookings/[id].ts
+++ b/src/pages/api/bookings/[id].ts
@@ -14,26 +14,32 @@ type Data = {
 };
 
 type Profile = {
-  id: string
-  first_name?: string | null
-  last_name?: string | null
-  username?: string | null
-  full_name?: string | null
-}
+  id: string;
+  first_name?: string | null;
+  last_name?: string | null;
+  username?: string | null;
+  full_name?: string | null;
+};
 
 type BookingRow = {
-  id: string
-  customer_name?: string | null
-  customer_id?: string | null
-  user_id?: string | null
-  profile_id?: string | null
-  guests?: number | null
-  room_type?: string | null
-  bed_type?: string | null
-  rooms?: { guests?: number | null; room_type?: string | null; bed_type?: string | null } | null
-  profiles?: Profile | null
-  [key: string]: unknown
-}
+  id: string;
+  customer_name?: string | null;
+  customer_id?: string | null;
+  user_id?: string | null;
+  profile_id?: string | null;
+  guests?: number | null;
+  room_type?: string | null;
+  bed_type?: string | null;
+  main_image_url?: string[] | null;
+  rooms?: {
+    guests?: number | null;
+    room_type?: string | null;
+    bed_type?: string | null;
+    main_image_url?: string[] | null;
+  } | null;
+  profiles?: Profile | null;
+  [key: string]: unknown;
+};
 
 export default async function handler(
   req: NextApiRequest,
@@ -41,6 +47,7 @@ export default async function handler(
 ) {
   const { id } = req.query as { id?: string };
 
+  // ✅ 1. Validate ID
   if (!id) {
     return res.status(400).json({
       success: false,
@@ -49,90 +56,117 @@ export default async function handler(
     });
   }
 
-  if (req.method === "GET") {
-    try {
-      // Attempt with profiles; if it fails, retry without to avoid breaking the UI
-      let data: BookingRow | null = null
-      let baseError: unknown = null
-      try {
-        const result = await supabase
-          .from("bookings")
-          .select("*, rooms(guests, room_type, bed_type), profiles(first_name, last_name, username, full_name)")
-          .eq("id", id)
-          .single();
-        data = (result.data as unknown as BookingRow) ?? null
-        baseError = result.error ?? null
-      } catch (e) {
-        baseError = e
-      }
-
-      if (baseError) {
-        const fallback = await supabase
-          .from("bookings")
-          .select("*, rooms(guests, room_type, bed_type)")
-          .eq("id", id)
-          .single();
-        if (fallback.error) {
-          return res.status(400).json({
-            success: false,
-            message: "Failed to fetch booking",
-            error: fallback.error.message,
-          });
-        }
-        data = (fallback.data as unknown as BookingRow) ?? null
-      }
-
-      // Enrich and synthesize name. If profiles join isn't present and customer_name is null, fetch profile by customer_id.
-      let enriched = data
-        ? (() => {
-            const profile = data?.profiles ?? null
-            const synthesizedName =
-              data?.customer_name
-              || profile?.full_name
-              || [profile?.first_name, profile?.last_name].filter(Boolean).join(" ")
-              || profile?.username
-              || null
-            return {
-              ...data,
-              customer_name: synthesizedName,
-              guests: data?.rooms?.guests ?? data?.guests ?? null,
-              room_type: data?.rooms?.room_type ?? data?.room_type ?? null,
-              bed_type: data?.rooms?.bed_type ?? data?.bed_type ?? null,
-            }
-          })()
-        : null
-
-      if (enriched && !enriched.customer_name && (enriched.customer_id || enriched.user_id || enriched.profile_id)) {
-        const key = String(enriched.customer_id || enriched.user_id || enriched.profile_id)
-        const { data: profile, error: profileError } = await supabase
-          .from("profiles")
-          .select("id, first_name, last_name, username, full_name")
-          .eq("id", key)
-          .single()
-        if (!profileError && profile) {
-          const synthesized = profile.full_name || [profile.first_name, profile.last_name].filter(Boolean).join(" ") || profile.username || null
-          enriched = { ...enriched, customer_name: synthesized }
-        }
-      }
-
-      return res.status(200).json({
-        success: true,
-        message: "Booking fetched successfully",
-        data: enriched,
-      });
-    } catch (error) {
-      return res.status(500).json({
-        success: false,
-        message: "Server error",
-        error: error instanceof Error ? error.message : "Unknown error",
-      });
-    }
+  // ✅ 2. Only allow GET
+  if (req.method !== "GET") {
+    return res.status(405).json({
+      success: false,
+      message: "Method not allowed. Use GET.",
+    });
   }
 
-  return res.status(405).json({
-    success: false,
-    message: "Method not allowed. Use GET.",
-  });
+  try {
+    // ✅ 3. Try main query (bookings + rooms + profiles)
+    const result = await supabase
+      .from("bookings")
+      .select(
+        `
+        *,
+        rooms(guests, room_type, bed_type, main_image_url),
+        profiles(first_name, last_name, username, full_name)
+      `
+      )
+      .eq("id", id)
+      .single();
+
+    let data = result.data as BookingRow | null;
+    const error = result.error;
+
+    // ✅ 4. Fallback if join fails
+    if (error) {
+      const fallback = await supabase
+        .from("bookings")
+        .select(
+          `
+          *,
+          rooms(guests, room_type, bed_type, main_image_url)
+        `
+        )
+        .eq("id", id)
+        .single();
+
+      if (fallback.error) {
+        return res.status(400).json({
+          success: false,
+          message: "Failed to fetch booking",
+          error: fallback.error.message,
+        });
+      }
+      data = fallback.data as BookingRow;
+    }
+
+    if (!data) {
+      return res.status(404).json({
+        success: false,
+        message: "Booking not found",
+      });
+    }
+
+    // ✅ 5. Enrich / synthesize data
+    const profile = data.profiles;
+    const synthesizedName =
+      data.customer_name ||
+      profile?.full_name ||
+      [profile?.first_name, profile?.last_name].filter(Boolean).join(" ") ||
+      profile?.username ||
+      null;
+
+    let enriched: BookingRow = {
+      ...data,
+      customer_name: synthesizedName,
+      guests: data.rooms?.guests ?? data.guests ?? null,
+      room_type: data.rooms?.room_type ?? data.room_type ?? null,
+      bed_type: data.rooms?.bed_type ?? data.bed_type ?? null,
+      main_image_url: data.rooms?.main_image_url ?? data.main_image_url ?? null,
+    };
+
+    // ✅ 6. If still missing name → fetch from profiles table
+    if (
+      !enriched.customer_name &&
+      (enriched.customer_id || enriched.user_id || enriched.profile_id)
+    ) {
+      const profileId =
+        enriched.customer_id || enriched.user_id || enriched.profile_id;
+
+      const { data: profileData, error: profileError } = await supabase
+        .from("profiles")
+        .select("id, first_name, last_name, username, full_name")
+        .eq("id", profileId)
+        .single();
+
+      if (!profileError && profileData) {
+        const synthesized =
+          profileData.full_name ||
+          [profileData.first_name, profileData.last_name]
+            .filter(Boolean)
+            .join(" ") ||
+          profileData.username ||
+          null;
+
+        enriched = { ...enriched, customer_name: synthesized };
+      }
+    }
+
+    // ✅ 7. Send success response
+    return res.status(200).json({
+      success: true,
+      message: "Booking fetched successfully",
+      data: enriched,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: "Server error",
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
 }
-
-

--- a/src/pages/customer/booking-history/index.tsx
+++ b/src/pages/customer/booking-history/index.tsx
@@ -89,6 +89,18 @@ function fmtDateUTC(d?: string | null) {
     "Oct",
     "Nov",
     "Dec",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
   ][dt.getUTCMonth()];
   const day = dt.getUTCDate();
   const year = dt.getUTCFullYear();

--- a/src/pages/customer/booking-history/index.tsx
+++ b/src/pages/customer/booking-history/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import Layout from "@/components/Layout";
-import Footer from "@/components/Footer";
 import BookingCard, {
   type Booking,
 } from "@/components/booking-history/BookingCard";

--- a/src/pages/customer/booking-history/index.tsx
+++ b/src/pages/customer/booking-history/index.tsx
@@ -592,7 +592,6 @@ export default function BookingHistoryPage() {
           </div>
         )}
       </main>
-      <Footer />
     </Layout>
   );
 }

--- a/src/pages/customer/customer-bookings/cancel/[bookingId]/cancel-completed.tsx
+++ b/src/pages/customer/customer-bookings/cancel/[bookingId]/cancel-completed.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import Layout from "@/components/Layout";
-import Image from "next/image";
 import { useQuery } from "@/hooks/useQuery";
 import LoadingScreen from "@/components/admin/LoadingScreen";
 import { formatDate } from "@/utils/formatDate";
@@ -55,7 +54,7 @@ export default function ChangeBookingPage() {
   // Update form fields when booking data is loaded
   useEffect(() => {}, [booking]);
 
-  if (!booking) {
+  if (!booking || loading) {
     return (
       <Layout>
         <LoadingScreen />
@@ -78,16 +77,16 @@ export default function ChangeBookingPage() {
   return (
     <Layout>
       <div className="bg-[#F7F7FB] flex flex-col justify-center items-center">
-        <div className="bg-green-700 md:h-[620px] w-full md:w-[750px] mt-10 md:mt-20 md:rounded-md">
+        <div className="bg-green-700 h-[580px] md:h-[500px] w-full md:w-[750px] mt-10 md:mt-20 md:rounded-md">
           <div className="bg-green-800 md:w-[750px] justify-center items-center text-center p-10 md:p-8 md:rounded-md">
             <h1 className="text-5xl md:text-4xl text-white font-noto mb-4">
-              Your Request has been Submitted
+              The Cancellation is Complete
             </h1>
-            <p className="text-green-400 text-sm">
+            <p className="text-green-400 text-md md:text-sm">
               The cancellation is complete.
             </p>
-            <p className="text-green-400 text-sm">
-              You will recieve an email with a detail and refund within 48
+            <p className="text-green-400 text-md md:text-sm">
+              You will recieve an email with a detail of cancellation within 24
               hours.
             </p>
           </div>
@@ -115,15 +114,6 @@ export default function ChangeBookingPage() {
                 Cancellation date: {cancelledDate}
               </p>
             </div>
-          </div>
-
-          <div className="border-b mx-10 mt-10 md:mt-0 border-green-500" />
-          {/* Total Refund */}
-          <div className="flex flex-row m-10 items-center justify-between">
-            <p className="text-white">Total Refund</p>
-            <p className="text-white font-bold text-xl">
-              THB {booking?.total_amount}
-            </p>
           </div>
         </div>
         <Button

--- a/src/pages/customer/customer-bookings/cancel/[bookingId]/index.tsx
+++ b/src/pages/customer/customer-bookings/cancel/[bookingId]/index.tsx
@@ -69,7 +69,7 @@ export default function ChangeBookingPage() {
   };
 
   const handleCancel = () => {
-    router.back();
+    router.push("/customer/booking-history");
   };
 
   if (loading || !booking) {

--- a/src/pages/customer/customer-bookings/cancel/[bookingId]/index.tsx
+++ b/src/pages/customer/customer-bookings/cancel/[bookingId]/index.tsx
@@ -7,6 +7,7 @@ import LoadingScreen from "@/components/admin/LoadingScreen";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import { formatDate } from "@/utils/formatDate";
 import { Button } from "@/components/admin/ui/Button";
+import { toast } from "sonner";
 
 interface RoomforBookings {
   guests: number;
@@ -47,13 +48,36 @@ export default function ChangeBookingPage() {
   const [checkOut, setCheckOut] = useState("");
   const [error, setError] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
+
+  // Only fetch when bookingId is available
+  const shouldFetch =
+    router.isReady && bookingId && typeof bookingId === "string";
 
   // Fetch booking data using useQuery
-  const { data: bookingResponse, loading } = useQuery<BookingApiResponse>(
-    `/api/bookings/${bookingId}`
+  const {
+    data: bookingResponse,
+    loading,
+    error: queryError,
+  } = useQuery<BookingApiResponse>(
+    shouldFetch ? `/api/bookings/${bookingId}` : ""
   );
 
   const booking = bookingResponse?.data;
+
+  // Handle query errors
+  useEffect(() => {
+    if (queryError) {
+      setError("Failed to load booking data");
+    }
+  }, [queryError]);
+
+  // Handle case where booking wasn't found
+  useEffect(() => {
+    if (!loading && shouldFetch && bookingResponse && !booking) {
+      setError("Booking not found");
+    }
+  }, [loading, shouldFetch, bookingResponse, booking]);
 
   // Update form fields when booking data is loaded
   useEffect(() => {
@@ -62,6 +86,50 @@ export default function ChangeBookingPage() {
       setCheckOut(booking.check_out_date);
     }
   }, [booking]);
+
+  const handleCancelBooking = async () => {
+    if (!booking) return;
+
+    setIsCancelling(true);
+
+    try {
+      const response = await fetch(`/api/bookings/${booking.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          status: "cancelled",
+          cancellation_date: new Date().toISOString(),
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to cancel booking");
+      }
+
+      toast.success("Booking cancelled successfully!");
+      setIsModalOpen(false);
+
+      // Delay redirect to show success message
+      setTimeout(() => {
+        router.push(
+          `/customer/customer-bookings/cancel/${bookingId}/cancel-completed`
+        );
+      }, 1000);
+    } catch (error) {
+      console.error("Error cancelling booking:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to cancel booking. Please try again."
+      );
+      setIsModalOpen(false);
+    } finally {
+      setIsCancelling(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -72,7 +140,8 @@ export default function ChangeBookingPage() {
     router.push("/customer/booking-history");
   };
 
-  if (loading || !booking) {
+  // Show loading while router is initializing OR data is loading
+  if (!router.isReady || loading || !shouldFetch) {
     return (
       <Layout>
         <LoadingScreen />
@@ -80,13 +149,41 @@ export default function ChangeBookingPage() {
     );
   }
 
-  if (error) {
+  // Show error state properly
+  if (error || queryError) {
     return (
       <Layout>
         <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
-          <p className="text-red-500">
-            {error ? "Error loading booking." : "Booking not found."}
-          </p>
+          <div className="text-center">
+            <p className="text-red-500 text-xl mb-4">
+              {error || "Error loading booking."}
+            </p>
+            <button
+              onClick={() => router.push("/customer/booking-history")}
+              className="px-6 py-2 bg-orange-600 text-white rounded hover:bg-orange-700"
+            >
+              Back to Booking History
+            </button>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  // Show not found state
+  if (!booking) {
+    return (
+      <Layout>
+        <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-gray-600 text-xl mb-4">Booking not found.</p>
+            <button
+              onClick={() => router.push("/customer/booking-history")}
+              className="px-6 py-2 bg-orange-600 text-white rounded hover:bg-orange-700"
+            >
+              Back to Booking History
+            </button>
+          </div>
         </div>
       </Layout>
     );
@@ -130,8 +227,8 @@ export default function ChangeBookingPage() {
                     </h2>
                     <p className="text-md text-gray-600 mt-3 md:mt-0">
                       Booking date:{" "}
-                      {booking.booking_date
-                        ? formatDate(booking.booking_date)
+                      {booking.created_at
+                        ? formatDate(booking.created_at)
                         : "N/A"}
                     </p>
                   </div>
@@ -157,7 +254,7 @@ export default function ChangeBookingPage() {
               <div className="md:hidden flex flex-col mx-5">
                 {/* Mobile Cancel Booking Button */}
                 <Button
-                  loading={false}
+                  loading={isCancelling}
                   text="Cancel this Booking"
                   onClick={() => setIsModalOpen(true)}
                   className="bg-orange-600 py-3 text-white w-full md:w-50 font-semibold font-inter md:hidden"
@@ -167,7 +264,8 @@ export default function ChangeBookingPage() {
                 <button
                   type="button"
                   onClick={handleCancel}
-                  className="md:hidden px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
+                  disabled={isCancelling}
+                  className="md:hidden px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Cancel
                 </button>
@@ -176,15 +274,11 @@ export default function ChangeBookingPage() {
               {isModalOpen && (
                 <ConfirmModal
                   open={isModalOpen}
-                  title="Change Date"
+                  title="Cancel Booking"
                   message="Are you sure you want to cancel this booking?"
                   confirmText="Yes, I want to cancel"
                   cancelText="No, I don't"
-                  onConfirm={() =>
-                    router.push(
-                      `/customer/customer-bookings/cancel/${bookingId}/cancel-completed`
-                    )
-                  }
+                  onConfirm={handleCancelBooking}
                   onClose={() => setIsModalOpen(false)}
                 />
               )}
@@ -195,14 +289,15 @@ export default function ChangeBookingPage() {
               <button
                 type="button"
                 onClick={handleCancel}
-                className="hidden md:block px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
+                disabled={isCancelling}
+                className="hidden md:block px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Cancel
               </button>
 
               {/* Desktop Cancel Booking Button */}
               <Button
-                loading={false}
+                loading={isCancelling}
                 text="Cancel this Booking"
                 onClick={() => setIsModalOpen(true)}
                 className="bg-orange-600 text-white w-50 font-semibold font-inter md:block hidden"

--- a/src/pages/customer/customer-bookings/cancel/[bookingId]/index.tsx
+++ b/src/pages/customer/customer-bookings/cancel/[bookingId]/index.tsx
@@ -3,10 +3,8 @@ import { useEffect, useState } from "react";
 import Layout from "@/components/Layout";
 import Image from "next/image";
 import { useQuery } from "@/hooks/useQuery";
-import OriginalBookingDetail from "@/components/booking/OriginalBookingDetail";
 import LoadingScreen from "@/components/admin/LoadingScreen";
 import ConfirmModal from "@/components/ui/ConfirmModal";
-import { calculateNights } from "@/utils/dateUtils";
 import { formatDate } from "@/utils/formatDate";
 import { Button } from "@/components/admin/ui/Button";
 
@@ -49,7 +47,6 @@ export default function ChangeBookingPage() {
   const [checkOut, setCheckOut] = useState("");
   const [error, setError] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [validationError, setValidationError] = useState("");
 
   // Fetch booking data using useQuery
   const { data: bookingResponse, loading } = useQuery<BookingApiResponse>(
@@ -66,86 +63,16 @@ export default function ChangeBookingPage() {
     }
   }, [booking]);
 
-  // Validate number of nights whenever dates change
-  useEffect(() => {
-    if (booking && checkIn && checkOut) {
-      const originalNights = calculateNights(
-        booking.check_in_date,
-        booking.check_out_date
-      );
-      const newNights = calculateNights(checkIn, checkOut);
-
-      if (newNights !== originalNights) {
-        setValidationError(
-          `Number of nights must match the original booking (${originalNights} ${
-            originalNights === 1 ? "night" : "nights"
-          }). Currently selected: ${newNights} ${
-            newNights === 1 ? "night" : "nights"
-          }.`
-        );
-      } else {
-        setValidationError("");
-      }
-    }
-  }, [checkIn, checkOut, booking]);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!booking) return;
-
-    // Final validation before submission
-    const originalNights = calculateNights(
-      booking.check_in_date,
-      booking.check_out_date
-    );
-    const newNights = calculateNights(checkIn, checkOut);
-
-    if (newNights !== originalNights) {
-      alert(
-        `Cannot update booking: Number of nights must match the original booking (${originalNights} ${
-          originalNights === 1 ? "night" : "nights"
-        }).`
-      );
-      return;
-    }
-
-    try {
-      const response = await fetch(`/api/bookings/${booking.id}`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          check_in_date: checkIn,
-          check_out_date: checkOut,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error("Failed to update booking");
-      }
-
-      alert("Booking updated successfully!");
-      router.push("/customer/booking-history");
-    } catch (error) {
-      console.error("Error updating booking:", error);
-      alert("Failed to update booking. Please try again.");
-    }
   };
 
   const handleCancel = () => {
     router.back();
   };
 
-  const handleOpenModal = () => {
-    // Prevent opening modal if validation fails
-    if (validationError) {
-      return;
-    }
-    setIsModalOpen(true);
-  };
-
-  if (!booking) {
+  if (loading || !booking) {
     return (
       <Layout>
         <LoadingScreen />
@@ -194,7 +121,7 @@ export default function ChangeBookingPage() {
               </div>
 
               {/* Booking Details Section */}
-              <div className="flex flex-col">
+              <div className="flex flex-col w-full">
                 <div className="md:w-full p-5 md:p-0 md:pl-15">
                   {/* Room Type and Booking Date Header */}
                   <div className="flex flex-col md:flex-row justify-between items-start mb-6">
@@ -250,10 +177,14 @@ export default function ChangeBookingPage() {
                 <ConfirmModal
                   open={isModalOpen}
                   title="Change Date"
-                  message="Are you sure you want to change your check-in and check-out date?"
-                  confirmText="Yes, I want to change"
+                  message="Are you sure you want to cancel this booking?"
+                  confirmText="Yes, I want to cancel"
                   cancelText="No, I don't"
-                  onConfirm={handleSubmit}
+                  onConfirm={() =>
+                    router.push(
+                      `/customer/customer-bookings/cancel/${bookingId}/cancel-completed`
+                    )
+                  }
                   onClose={() => setIsModalOpen(false)}
                 />
               )}

--- a/src/pages/customer/customer-bookings/cancel/[bookingId]/index.tsx
+++ b/src/pages/customer/customer-bookings/cancel/[bookingId]/index.tsx
@@ -1,0 +1,285 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import Layout from "@/components/Layout";
+import Image from "next/image";
+import { useQuery } from "@/hooks/useQuery";
+import OriginalBookingDetail from "@/components/booking/OriginalBookingDetail";
+import LoadingScreen from "@/components/admin/LoadingScreen";
+import ConfirmModal from "@/components/ui/ConfirmModal";
+import { calculateNights } from "@/utils/dateUtils";
+import { formatDate } from "@/utils/formatDate";
+import { Button } from "@/components/admin/ui/Button";
+
+interface RoomforBookings {
+  guests: number;
+  bed_type: string;
+  room_type: string;
+  main_image_url: string[];
+}
+
+interface Booking {
+  id: string;
+  user_id: string;
+  room_id: string;
+  customer_id: string;
+  status: "pending" | "confirmed" | "cancelled" | "refunded";
+  booking_date: string;
+  payment_method: string;
+  check_in_date: string;
+  check_out_date: string;
+  total_amount: number;
+  special_requests?: string[];
+  additional_request?: string[];
+  standard_request?: string[];
+  created_at: string;
+  rooms?: RoomforBookings | undefined;
+}
+
+type BookingApiResponse = {
+  success: boolean;
+  message: string;
+  data?: Booking | null;
+  error?: string;
+};
+
+export default function ChangeBookingPage() {
+  const router = useRouter();
+  const { bookingId } = router.query;
+  const [checkIn, setCheckIn] = useState("");
+  const [checkOut, setCheckOut] = useState("");
+  const [error, setError] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [validationError, setValidationError] = useState("");
+
+  // Fetch booking data using useQuery
+  const { data: bookingResponse, loading } = useQuery<BookingApiResponse>(
+    `/api/bookings/${bookingId}`
+  );
+
+  const booking = bookingResponse?.data;
+
+  // Update form fields when booking data is loaded
+  useEffect(() => {
+    if (booking) {
+      setCheckIn(booking.check_in_date);
+      setCheckOut(booking.check_out_date);
+    }
+  }, [booking]);
+
+  // Validate number of nights whenever dates change
+  useEffect(() => {
+    if (booking && checkIn && checkOut) {
+      const originalNights = calculateNights(
+        booking.check_in_date,
+        booking.check_out_date
+      );
+      const newNights = calculateNights(checkIn, checkOut);
+
+      if (newNights !== originalNights) {
+        setValidationError(
+          `Number of nights must match the original booking (${originalNights} ${
+            originalNights === 1 ? "night" : "nights"
+          }). Currently selected: ${newNights} ${
+            newNights === 1 ? "night" : "nights"
+          }.`
+        );
+      } else {
+        setValidationError("");
+      }
+    }
+  }, [checkIn, checkOut, booking]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!booking) return;
+
+    // Final validation before submission
+    const originalNights = calculateNights(
+      booking.check_in_date,
+      booking.check_out_date
+    );
+    const newNights = calculateNights(checkIn, checkOut);
+
+    if (newNights !== originalNights) {
+      alert(
+        `Cannot update booking: Number of nights must match the original booking (${originalNights} ${
+          originalNights === 1 ? "night" : "nights"
+        }).`
+      );
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/bookings/${booking.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          check_in_date: checkIn,
+          check_out_date: checkOut,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to update booking");
+      }
+
+      alert("Booking updated successfully!");
+      router.push("/customer/booking-history");
+    } catch (error) {
+      console.error("Error updating booking:", error);
+      alert("Failed to update booking. Please try again.");
+    }
+  };
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  const handleOpenModal = () => {
+    // Prevent opening modal if validation fails
+    if (validationError) {
+      return;
+    }
+    setIsModalOpen(true);
+  };
+
+  if (!booking) {
+    return (
+      <Layout>
+        <LoadingScreen />
+      </Layout>
+    );
+  }
+
+  if (error) {
+    return (
+      <Layout>
+        <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
+          <p className="text-red-500">
+            {error ? "Error loading booking." : "Booking not found."}
+          </p>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="min-h-screen bg-[#F7F7FB]">
+        <div className="min-w-screen md:px-20 pt-25">
+          {/* Header */}
+          <h1 className="text-6xl md:text-7xl text-green-700 mb-10 md:mb-12 font-noto font-medium px-5 ">
+            Cancel Booking
+          </h1>
+
+          {/* Booking Card */}
+          <div className="bg-[#F7F7FB] md:mt-30">
+            <div className="flex flex-col md:flex-row border-b border-gray-500/50 pb-10 mb-10">
+              {/* Room Image */}
+              <div>
+                {/* Room Image */}
+                <div className="w-full md:w-[370px] h-50 md:h-[200px] relative md:rounded-md overflow-hidden">
+                  <Image
+                    src={
+                      booking?.rooms?.main_image_url[0] ||
+                      "https://images.unsplash.com/photo-1566073771259-6a8506099945"
+                    }
+                    alt={booking?.rooms?.room_type || "room-image"}
+                    fill
+                    className="block object-cover"
+                  />
+                </div>
+              </div>
+
+              {/* Booking Details Section */}
+              <div className="flex flex-col">
+                <div className="md:w-full p-5 md:p-0 md:pl-15">
+                  {/* Room Type and Booking Date Header */}
+                  <div className="flex flex-col md:flex-row justify-between items-start mb-6">
+                    <h2 className="text-5xl md:text-4xl font-semibold text-black font-inter mt-2">
+                      {booking?.rooms?.room_type}
+                    </h2>
+                    <p className="text-md text-gray-600 mt-3 md:mt-0">
+                      Booking date:{" "}
+                      {booking.booking_date
+                        ? formatDate(booking.booking_date)
+                        : "N/A"}
+                    </p>
+                  </div>
+
+                  {/* Original Dates */}
+                  <div className="mt-10">
+                    <p className="text-gray-700 text-md">
+                      {formatDate(booking.check_in_date)} -{" "}
+                      {formatDate(booking.check_out_date)}
+                    </p>
+                    <p className="text-md text-gray-800">
+                      {booking?.rooms?.guests} guests
+                    </p>
+                  </div>
+
+                  <p className="text-[#B61615] mt-10">
+                    Cancellation of the booking now will not be able to request
+                    a refund
+                  </p>
+                </div>
+              </div>
+
+              <div className="md:hidden flex flex-col mx-5">
+                {/* Mobile Cancel Booking Button */}
+                <Button
+                  loading={false}
+                  text="Cancel this Booking"
+                  onClick={() => setIsModalOpen(true)}
+                  className="bg-orange-600 py-3 text-white w-full md:w-50 font-semibold font-inter md:hidden"
+                />
+
+                {/* Mobile Cancel Button */}
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="md:hidden px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
+                >
+                  Cancel
+                </button>
+              </div>
+              {/* Confirm Modal */}
+              {isModalOpen && (
+                <ConfirmModal
+                  open={isModalOpen}
+                  title="Change Date"
+                  message="Are you sure you want to change your check-in and check-out date?"
+                  confirmText="Yes, I want to change"
+                  cancelText="No, I don't"
+                  onConfirm={handleSubmit}
+                  onClose={() => setIsModalOpen(false)}
+                />
+              )}
+            </div>
+
+            {/* Desktop Cancel Button */}
+            <div className="flex w-full justify-between">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="hidden md:block px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+
+              {/* Desktop Cancel Booking Button */}
+              <Button
+                loading={false}
+                text="Cancel this Booking"
+                onClick={() => setIsModalOpen(true)}
+                className="bg-orange-600 text-white w-50 font-semibold font-inter md:block hidden"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/src/pages/customer/customer-bookings/cancel/[bookingId]/refund-request.tsx
+++ b/src/pages/customer/customer-bookings/cancel/[bookingId]/refund-request.tsx
@@ -62,7 +62,7 @@ export default function ChangeBookingPage() {
   }, [booking]);
 
   const handleCancel = () => {
-    router.back();
+    router.push("/customer/booking-history");
   };
 
   if (!booking) {
@@ -144,7 +144,7 @@ export default function ChangeBookingPage() {
                     {/* Total Refund */}
                     <div className="mt-10">
                       <p>Total Refund</p>
-                      <p className="font-semibold md:font-normal text-2xl md:text-sm">
+                      <p className="font-semibold md:font-bold text-2xl md:text-lg">
                         THB {booking?.total_amount}
                       </p>
                     </div>

--- a/src/pages/customer/customer-bookings/cancel/[bookingId]/refund-request.tsx
+++ b/src/pages/customer/customer-bookings/cancel/[bookingId]/refund-request.tsx
@@ -1,0 +1,206 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import Layout from "@/components/Layout";
+import Image from "next/image";
+import { useQuery } from "@/hooks/useQuery";
+import LoadingScreen from "@/components/admin/LoadingScreen";
+import { formatDate } from "@/utils/formatDate";
+import { Button } from "@/components/admin/ui/Button";
+
+interface RoomforBookings {
+  guests: number;
+  bed_type: string;
+  room_type: string;
+  main_image_url: string[];
+}
+
+interface Booking {
+  id: string;
+  user_id: string;
+  room_id: string;
+  customer_id: string;
+  status: "pending" | "confirmed" | "cancelled" | "refunded";
+  booking_date: string;
+  payment_method: string;
+  check_in_date: string;
+  check_out_date: string;
+  total_amount: number;
+  special_requests?: string[];
+  additional_request?: string[];
+  standard_request?: string[];
+  created_at: string;
+  rooms?: RoomforBookings | undefined;
+}
+
+type BookingApiResponse = {
+  success: boolean;
+  message: string;
+  data?: Booking | null;
+  error?: string;
+};
+
+export default function ChangeBookingPage() {
+  const router = useRouter();
+  const { bookingId } = router.query;
+  const [checkIn, setCheckIn] = useState("");
+  const [checkOut, setCheckOut] = useState("");
+  const [error, setError] = useState("");
+
+  // Fetch booking data using useQuery
+  const { data: bookingResponse, loading } = useQuery<BookingApiResponse>(
+    `/api/bookings/${bookingId}`
+  );
+
+  const booking = bookingResponse?.data;
+
+  // Update form fields when booking data is loaded
+  useEffect(() => {
+    if (booking) {
+      setCheckIn(booking.check_in_date);
+      setCheckOut(booking.check_out_date);
+    }
+  }, [booking]);
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  if (!booking) {
+    return (
+      <Layout>
+        <LoadingScreen />
+      </Layout>
+    );
+  }
+
+  if (error) {
+    return (
+      <Layout>
+        <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
+          <p className="text-red-500">
+            {error ? "Error loading booking." : "Booking not found."}
+          </p>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="min-h-screen bg-[#F7F7FB]">
+        <div className="min-w-screen md:px-20 pt-25">
+          {/* Header */}
+          <h1 className="text-5xl md:text-7xl text-green-700 mb-10 md:mb-12 font-noto font-medium px-5 ">
+            Request a Refund
+          </h1>
+
+          {/* Booking Card */}
+          <div className="bg-[#F7F7FB] md:mt-30">
+            <div className="flex flex-col md:flex-row border-b border-gray-500/50 pb-10 mb-10">
+              {/* Room Image */}
+              <div>
+                {/* Room Image */}
+                <div className="w-full md:w-[370px] h-50 md:h-[200px] relative md:rounded-md overflow-hidden">
+                  <Image
+                    src={
+                      booking?.rooms?.main_image_url[0] ||
+                      "https://images.unsplash.com/photo-1566073771259-6a8506099945"
+                    }
+                    alt={booking?.rooms?.room_type || "room-image"}
+                    fill
+                    className="block object-cover"
+                  />
+                </div>
+              </div>
+
+              {/* Booking Details Section */}
+              <div className="flex flex-col w-full">
+                <div className="md:w-full p-5 md:p-0 md:pl-15">
+                  {/* Room Type and Booking Date Header */}
+                  <div className="flex flex-col md:flex-row justify-between items-start mb-6">
+                    <h2 className="text-5xl md:text-4xl font-semibold text-black font-inter mt-2">
+                      {booking?.rooms?.room_type}
+                    </h2>
+                    <p className="text-md text-gray-600 mt-3 md:mt-0">
+                      Booking date:{" "}
+                      {booking.booking_date
+                        ? formatDate(booking.booking_date)
+                        : "N/A"}
+                    </p>
+                  </div>
+
+                  <div className="flex flex-col md:flex-row justify-between">
+                    {/* Original Dates */}
+                    <div className="mt-10">
+                      <p className="text-gray-700 text-md">
+                        {formatDate(booking.check_in_date)} -{" "}
+                        {formatDate(booking.check_out_date)}
+                      </p>
+                      <p className="text-md text-gray-800">
+                        {booking?.rooms?.guests} guests
+                      </p>
+                    </div>
+
+                    {/* Total Refund */}
+                    <div className="mt-10">
+                      <p>Total Refund</p>
+                      <p className="font-semibold md:font-normal text-2xl md:text-sm">
+                        THB {booking?.total_amount}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="md:hidden flex flex-col mx-5">
+                {/* Mobile Refund Booking Button */}
+                <Button
+                  loading={false}
+                  text="Cancel and Refund this Booking"
+                  onClick={() =>
+                    router.push(
+                      `/customer/customer-bookings/cancel/${bookingId}/refund-submitted`
+                    )
+                  }
+                  className="bg-orange-600 py-3 text-white w-full md:w-50 font-semibold font-inter md:hidden"
+                />
+
+                {/* Mobile Cancel Button */}
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="md:hidden px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+
+            {/* Desktop Cancel Button */}
+            <div className="flex w-full justify-between">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="hidden md:block px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+
+              {/* Desktop Cancel Booking Button */}
+              <Button
+                loading={false}
+                text="Cancel and Refund this Booking"
+                onClick={() =>
+                  router.push(
+                    `/customer/customer-bookings/cancel/${bookingId}/refund-submitted`
+                  )
+                }
+                className="bg-orange-600 text-white w-80 font-semibold font-inter md:block hidden"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/src/pages/customer/customer-bookings/cancel/[bookingId]/refund-request.tsx
+++ b/src/pages/customer/customer-bookings/cancel/[bookingId]/refund-request.tsx
@@ -4,8 +4,10 @@ import Layout from "@/components/Layout";
 import Image from "next/image";
 import { useQuery } from "@/hooks/useQuery";
 import LoadingScreen from "@/components/admin/LoadingScreen";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import { formatDate } from "@/utils/formatDate";
 import { Button } from "@/components/admin/ui/Button";
+import { toast } from "sonner";
 
 interface RoomforBookings {
   guests: number;
@@ -39,19 +41,43 @@ type BookingApiResponse = {
   error?: string;
 };
 
-export default function ChangeBookingPage() {
+export default function RefundBookingPage() {
   const router = useRouter();
   const { bookingId } = router.query;
   const [checkIn, setCheckIn] = useState("");
   const [checkOut, setCheckOut] = useState("");
   const [error, setError] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isRefunding, setIsRefunding] = useState(false);
+
+  // Only fetch when bookingId is available
+  const shouldFetch =
+    router.isReady && bookingId && typeof bookingId === "string";
 
   // Fetch booking data using useQuery
-  const { data: bookingResponse, loading } = useQuery<BookingApiResponse>(
-    `/api/bookings/${bookingId}`
+  const {
+    data: bookingResponse,
+    loading,
+    error: queryError,
+  } = useQuery<BookingApiResponse>(
+    shouldFetch ? `/api/bookings/${bookingId}` : ""
   );
 
   const booking = bookingResponse?.data;
+
+  // Handle query errors
+  useEffect(() => {
+    if (queryError) {
+      setError("Failed to load booking data");
+    }
+  }, [queryError]);
+
+  // Handle case where booking wasn't found
+  useEffect(() => {
+    if (!loading && shouldFetch && bookingResponse && !booking) {
+      setError("Booking not found");
+    }
+  }, [loading, shouldFetch, bookingResponse, booking]);
 
   // Update form fields when booking data is loaded
   useEffect(() => {
@@ -61,11 +87,56 @@ export default function ChangeBookingPage() {
     }
   }, [booking]);
 
+  const handleRefundBooking = async () => {
+    if (!booking) return;
+
+    setIsRefunding(true);
+
+    try {
+      const response = await fetch(`/api/bookings/${booking.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          status: "refunded",
+          cancellation_date: new Date().toISOString(),
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to process refund");
+      }
+
+      toast.success("Refund request submitted successfully!");
+      setIsModalOpen(false);
+
+      // Delay redirect to show success message
+      setTimeout(() => {
+        router.push(
+          `/customer/customer-bookings/cancel/${bookingId}/refund-submitted`
+        );
+      }, 1000);
+    } catch (error) {
+      console.error("Error processing refund:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to process refund. Please try again."
+      );
+      setIsModalOpen(false);
+    } finally {
+      setIsRefunding(false);
+    }
+  };
+
   const handleCancel = () => {
     router.push("/customer/booking-history");
   };
 
-  if (!booking) {
+  // Show loading while router is initializing OR data is loading
+  if (!router.isReady || loading || !shouldFetch) {
     return (
       <Layout>
         <LoadingScreen />
@@ -73,13 +144,41 @@ export default function ChangeBookingPage() {
     );
   }
 
-  if (error) {
+  // Show error state properly
+  if (error || queryError) {
     return (
       <Layout>
         <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
-          <p className="text-red-500">
-            {error ? "Error loading booking." : "Booking not found."}
-          </p>
+          <div className="text-center">
+            <p className="text-red-500 text-xl mb-4">
+              {error || "Error loading booking."}
+            </p>
+            <button
+              onClick={() => router.push("/customer/booking-history")}
+              className="px-6 py-2 bg-orange-600 text-white rounded hover:bg-orange-700"
+            >
+              Back to Booking History
+            </button>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  // Show not found state
+  if (!booking) {
+    return (
+      <Layout>
+        <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-gray-600 text-xl mb-4">Booking not found.</p>
+            <button
+              onClick={() => router.push("/customer/booking-history")}
+              className="px-6 py-2 bg-orange-600 text-white rounded hover:bg-orange-700"
+            >
+              Back to Booking History
+            </button>
+          </div>
         </div>
       </Layout>
     );
@@ -123,8 +222,8 @@ export default function ChangeBookingPage() {
                     </h2>
                     <p className="text-md text-gray-600 mt-3 md:mt-0">
                       Booking date:{" "}
-                      {booking.booking_date
-                        ? formatDate(booking.booking_date)
+                      {booking.created_at
+                        ? formatDate(booking.created_at)
                         : "N/A"}
                     </p>
                   </div>
@@ -155,13 +254,9 @@ export default function ChangeBookingPage() {
               <div className="md:hidden flex flex-col mx-5">
                 {/* Mobile Refund Booking Button */}
                 <Button
-                  loading={false}
+                  loading={isRefunding}
                   text="Cancel and Refund this Booking"
-                  onClick={() =>
-                    router.push(
-                      `/customer/customer-bookings/cancel/${bookingId}/refund-submitted`
-                    )
-                  }
+                  onClick={() => setIsModalOpen(true)}
                   className="bg-orange-600 py-3 text-white w-full md:w-50 font-semibold font-inter md:hidden"
                 />
 
@@ -169,11 +264,25 @@ export default function ChangeBookingPage() {
                 <button
                   type="button"
                   onClick={handleCancel}
-                  className="md:hidden px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
+                  disabled={isRefunding}
+                  className="md:hidden px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Cancel
                 </button>
               </div>
+
+              {/* Confirm Modal */}
+              {isModalOpen && (
+                <ConfirmModal
+                  open={isModalOpen}
+                  title="Request Refund"
+                  message={`Are you sure you want to cancel this booking and request a refund of THB ${booking?.total_amount}?`}
+                  confirmText="Yes, Request Refund"
+                  cancelText="No, Keep Booking"
+                  onConfirm={handleRefundBooking}
+                  onClose={() => setIsModalOpen(false)}
+                />
+              )}
             </div>
 
             {/* Desktop Cancel Button */}
@@ -181,20 +290,17 @@ export default function ChangeBookingPage() {
               <button
                 type="button"
                 onClick={handleCancel}
-                className="hidden md:block px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
+                disabled={isRefunding}
+                className="hidden md:block px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Cancel
               </button>
 
               {/* Desktop Cancel Booking Button */}
               <Button
-                loading={false}
+                loading={isRefunding}
                 text="Cancel and Refund this Booking"
-                onClick={() =>
-                  router.push(
-                    `/customer/customer-bookings/cancel/${bookingId}/refund-submitted`
-                  )
-                }
+                onClick={() => setIsModalOpen(true)}
                 className="bg-orange-600 text-white w-80 font-semibold font-inter md:block hidden"
               />
             </div>

--- a/src/pages/customer/customer-bookings/cancel/[bookingId]/refund-submitted.tsx
+++ b/src/pages/customer/customer-bookings/cancel/[bookingId]/refund-submitted.tsx
@@ -92,7 +92,7 @@ export default function ChangeBookingPage() {
             </p>
           </div>
 
-          <div className="flex flex-col bg-green-600 m-5 md:m-10 p-5 rounded-md">
+          <div className="flex flex-col bg-green-600 m-5 md:m-10 p-5 md:rounded-md">
             <p className="text-white font-bold text-3xl md:text-xl">
               {booking?.rooms?.room_type}
             </p>

--- a/src/pages/customer/customer-bookings/change/[bookingId].tsx
+++ b/src/pages/customer/customer-bookings/change/[bookingId].tsx
@@ -135,7 +135,7 @@ export default function ChangeBookingPage() {
   };
 
   const handleCancel = () => {
-    router.back();
+    router.push("/customer/booking-history");
   };
 
   const handleOpenModal = () => {
@@ -183,9 +183,6 @@ export default function ChangeBookingPage() {
             <br className="hidden md:block" />
             <span>and Check-out Date</span>
           </h1>
-          <button onClick={() => toast.success("Test toast!")}>
-            Test Toast
-          </button>
 
           {/* Booking Card */}
           <div className="bg-[#F7F7FB] md:mt-30">

--- a/src/pages/customer/customer-bookings/change/[bookingId].tsx
+++ b/src/pages/customer/customer-bookings/change/[bookingId].tsx
@@ -8,6 +8,7 @@ import OriginalBookingDetail from "@/components/booking/OriginalBookingDetail";
 import LoadingScreen from "@/components/admin/LoadingScreen";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import { calculateNights } from "@/utils/dateUtils";
+import { toast } from "sonner";
 
 interface RoomforBookings {
   guests: number;
@@ -98,7 +99,7 @@ export default function ChangeBookingPage() {
     const newNights = calculateNights(checkIn, checkOut);
 
     if (newNights !== originalNights) {
-      alert(
+      toast.error(
         `Cannot update booking: Number of nights must match the original booking (${originalNights} ${
           originalNights === 1 ? "night" : "nights"
         }).`
@@ -122,11 +123,14 @@ export default function ChangeBookingPage() {
         throw new Error("Failed to update booking");
       }
 
-      alert("Booking updated successfully!");
-      router.push("/customer/booking-history");
+      toast.success("Booking updated successfully!");
+      // Delay redirect to allow toast to be visible
+      setTimeout(() => {
+        router.push("/customer/booking-history");
+      }, 1000);
     } catch (error) {
       console.error("Error updating booking:", error);
-      alert("Failed to update booking. Please try again.");
+      toast.error("Failed to update booking. Please try again.");
     }
   };
 
@@ -179,6 +183,9 @@ export default function ChangeBookingPage() {
             <br className="hidden md:block" />
             <span>and Check-out Date</span>
           </h1>
+          <button onClick={() => toast.success("Test toast!")}>
+            Test Toast
+          </button>
 
           {/* Booking Card */}
           <div className="bg-[#F7F7FB] md:mt-30">

--- a/src/pages/customer/customer-bookings/change/[bookingId].tsx
+++ b/src/pages/customer/customer-bookings/change/[bookingId].tsx
@@ -3,51 +3,55 @@ import { useEffect, useState } from "react";
 import Layout from "@/components/Layout";
 import Image from "next/image";
 import { useQuery } from "@/hooks/useQuery";
-import { formatDate } from "@/utils/formatDate";
+import ChangeDateForm from "@/components/booking/ChangeDateForm";
+import OriginalBookingDetail from "@/components/booking/OriginalBookingDetail";
+import LoadingScreen from "@/components/admin/LoadingScreen";
+import ConfirmModal from "@/components/ui/ConfirmModal";
+import { calculateNights } from "@/utils/dateUtils";
 
-import ChangeDateForm from "@/components/booking/changeDateForm";
+interface RoomforBookings {
+  guests: number;
+  bed_type: string;
+  room_type: string;
+  main_image_url: string[];
+}
+
+interface Booking {
+  id: string;
+  user_id: string;
+  room_id: string;
+  customer_id: string;
+  status: "pending" | "confirmed" | "cancelled" | "refunded";
+  booking_date: string;
+  payment_method: string;
+  check_in_date: string;
+  check_out_date: string;
+  total_amount: number;
+  special_requests?: string[];
+  additional_request?: string[];
+  standard_request?: string[];
+  created_at: string;
+  rooms?: RoomforBookings | undefined;
+}
+
+type BookingApiResponse = {
+  success: boolean;
+  message: string;
+  data?: Booking | null;
+  error?: string;
+};
+
 export default function ChangeBookingPage() {
   const router = useRouter();
   const { bookingId } = router.query;
   const [checkIn, setCheckIn] = useState("");
   const [checkOut, setCheckOut] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-
-  interface RoomforBookings {
-    guests: number;
-    bed_type: string;
-    room_type: string;
-    main_image_url: string[];
-  }
-
-  interface Booking {
-    id: string;
-    user_id: string;
-    room_id: string;
-    customer_id: string;
-    status: "pending" | "confirmed" | "cancelled" | "refunded";
-    booking_date: string;
-    payment_method: string;
-    check_in_date: string;
-    check_out_date: string;
-    total_amount: number;
-    special_requests?: string[];
-    additional_request?: string[];
-    standard_request?: string[];
-    created_at: string;
-    rooms?: RoomforBookings | undefined;
-  }
-
-  type BookingApiResponse = {
-    success: boolean;
-    message: string;
-    data?: Booking | null;
-    error?: string;
-  };
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [validationError, setValidationError] = useState("");
 
   // Fetch booking data using useQuery
-  const { data: bookingResponse } = useQuery<BookingApiResponse>(
+  const { data: bookingResponse, loading } = useQuery<BookingApiResponse>(
     `/api/bookings/${bookingId}`
   );
 
@@ -61,13 +65,52 @@ export default function ChangeBookingPage() {
     }
   }, [booking]);
 
+  // Validate number of nights whenever dates change
+  useEffect(() => {
+    if (booking && checkIn && checkOut) {
+      const originalNights = calculateNights(
+        booking.check_in_date,
+        booking.check_out_date
+      );
+      const newNights = calculateNights(checkIn, checkOut);
+
+      if (newNights !== originalNights) {
+        setValidationError(
+          `Number of nights must match the original booking (${originalNights} ${
+            originalNights === 1 ? "night" : "nights"
+          }). Currently selected: ${newNights} ${
+            newNights === 1 ? "night" : "nights"
+          }.`
+        );
+      } else {
+        setValidationError("");
+      }
+    }
+  }, [checkIn, checkOut, booking]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!booking) return;
 
+    // Final validation before submission
+    const originalNights = calculateNights(
+      booking.check_in_date,
+      booking.check_out_date
+    );
+    const newNights = calculateNights(checkIn, checkOut);
+
+    if (newNights !== originalNights) {
+      alert(
+        `Cannot update booking: Number of nights must match the original booking (${originalNights} ${
+          originalNights === 1 ? "night" : "nights"
+        }).`
+      );
+      return;
+    }
+
     try {
       const response = await fetch(`/api/bookings/${booking.id}`, {
-        method: "PATCH",
+        method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
@@ -82,7 +125,7 @@ export default function ChangeBookingPage() {
       }
 
       alert("Booking updated successfully!");
-      router.push("/booking-history");
+      router.push("/customer/booking-history");
     } catch (error) {
       console.error("Error updating booking:", error);
       alert("Failed to update booking. Please try again.");
@@ -93,17 +136,23 @@ export default function ChangeBookingPage() {
     router.back();
   };
 
-  if (isLoading) {
+  const handleOpenModal = () => {
+    // Prevent opening modal if validation fails
+    if (validationError) {
+      return;
+    }
+    setIsModalOpen(true);
+  };
+
+  if (!booking) {
     return (
       <Layout>
-        <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
-          <p className="text-gray-600">Loading booking details...</p>
-        </div>
+        <LoadingScreen />
       </Layout>
     );
   }
 
-  if (error || !booking) {
+  if (error) {
     return (
       <Layout>
         <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
@@ -114,6 +163,11 @@ export default function ChangeBookingPage() {
       </Layout>
     );
   }
+
+  const originalNights = calculateNights(
+    booking.check_in_date,
+    booking.check_out_date
+  );
 
   return (
     <Layout>
@@ -137,10 +191,10 @@ export default function ChangeBookingPage() {
                 <div className="w-full md:w-[370px] h-50 md:h-[200px] relative md:rounded-md overflow-hidden">
                   <Image
                     src={
-                      booking.rooms?.main_image_url[0] ||
+                      booking?.rooms?.main_image_url[0] ||
                       "https://images.unsplash.com/photo-1566073771259-6a8506099945"
                     }
-                    alt={booking.rooms?.room_type || "room-image"}
+                    alt={booking?.rooms?.room_type || "room-image"}
                     fill
                     className="block object-cover"
                   />
@@ -151,47 +205,66 @@ export default function ChangeBookingPage() {
                   <button
                     type="button"
                     onClick={handleCancel}
-                    className="hidden md:block px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors"
+                    className="hidden md:block px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors cursor-pointer"
                   >
                     Cancel
                   </button>
                 </div>
               </div>
 
-              {/* Booking Details */}
-              <div className="md:w-full p-5 md:p-0 md:pl-15">
-                <div className="flex flex-col md:flex-row justify-between items-start mb-6">
-                  <h2 className="text-3xl md:text-4xl font-bold text-black font-inter mt-2">
-                    {booking.rooms?.room_type}
-                  </h2>
-                  <p className="text-md text-gray-600">
-                    Booking date:{" "}
-                    {booking?.booking_date
-                      ? formatDate(booking.booking_date)
-                      : "N/A"}
+              {/* Booking Details Section */}
+              <div className="md:w-full">
+                {/* Original Booking Detail Component */}
+                {booking && (
+                  <OriginalBookingDetail
+                    roomType={booking?.rooms?.room_type}
+                    bookingDate={booking?.booking_date}
+                    checkInDate={booking?.check_in_date}
+                    checkOutDate={booking?.check_out_date}
+                  />
+                )}
+
+                {/* Validation Error Message */}
+                {validationError && (
+                  <div className="p-5 md:p-0 md:pl-15 mb-4">
+                    <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+                      {validationError}
+                    </div>
+                  </div>
+                )}
+
+                {/* Display original nights info */}
+                <div className="p-5 md:p-0 md:pl-15 mb-4">
+                  <p className="text-gray-600 text-sm">
+                    Original booking: {originalNights}{" "}
+                    {originalNights === 1 ? "night" : "nights"}
                   </p>
                 </div>
 
-                {/* Original Dates */}
-                <div className="mb-8">
-                  <p className="text-lg font-semibold text-gray-800 mb-2">
-                    Original Date
-                  </p>
-                  <p className="text-gray-700 text-md">
-                    {formatDate(booking.check_in_date)} -{" "}
-                    {formatDate(booking.check_out_date)}
-                  </p>
-                </div>
+                {isModalOpen && (
+                  <ConfirmModal
+                    open={isModalOpen}
+                    title="Change Date"
+                    message="Are you sure you want to change your check-in and check-out date?"
+                    confirmText="Yes, I want to change"
+                    cancelText="No, I don't"
+                    onConfirm={handleSubmit}
+                    onClose={() => setIsModalOpen(false)}
+                  />
+                )}
 
-                {/* Change Date Form Component */}
-                <ChangeDateForm
-                  checkIn={checkIn}
-                  checkOut={checkOut}
-                  onCheckInChange={setCheckIn}
-                  onCheckOutChange={setCheckOut}
-                  onSubmit={handleSubmit}
-                  onCancel={handleCancel}
-                />
+                {/* Change Date Form Component - wrapped in padding div */}
+                <div className="p-5 md:p-0 md:pl-15">
+                  <ChangeDateForm
+                    checkIn={checkIn}
+                    checkOut={checkOut}
+                    onCheckInChange={setCheckIn}
+                    onCheckOutChange={setCheckOut}
+                    onSubmit={handleSubmit}
+                    onClick={handleOpenModal}
+                    onCancel={handleCancel}
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/src/pages/customer/customer-bookings/change/[bookingId].tsx
+++ b/src/pages/customer/customer-bookings/change/[bookingId].tsx
@@ -50,13 +50,37 @@ export default function ChangeBookingPage() {
   const [error, setError] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [validationError, setValidationError] = useState("");
+  const today = new Date().toISOString().split("T")[0];
 
-  // Fetch booking data using useQuery
-  const { data: bookingResponse, loading } = useQuery<BookingApiResponse>(
-    `/api/bookings/${bookingId}`
+  // KEY FIX 1: Only fetch when bookingId is available
+  // Wait for router to be ready and bookingId to be a string
+  const shouldFetch =
+    router.isReady && bookingId && typeof bookingId === "string";
+
+  // Fetch booking data using useQuery - only pass URL when ready
+  const {
+    data: bookingResponse,
+    loading,
+    error: queryError,
+  } = useQuery<BookingApiResponse>(
+    shouldFetch ? `/api/bookings/${bookingId}` : "" // Pass empty string to skip fetch
   );
 
   const booking = bookingResponse?.data;
+
+  // KEY FIX 2: Handle query errors
+  useEffect(() => {
+    if (queryError) {
+      setError("Failed to load booking data");
+    }
+  }, [queryError]);
+
+  // KEY FIX 3: Handle case where booking wasn't found
+  useEffect(() => {
+    if (!loading && shouldFetch && bookingResponse && !booking) {
+      setError("Booking not found");
+    }
+  }, [loading, shouldFetch, bookingResponse, booking]);
 
   // Update form fields when booking data is loaded
   useEffect(() => {
@@ -146,7 +170,8 @@ export default function ChangeBookingPage() {
     setIsModalOpen(true);
   };
 
-  if (!booking) {
+  // KEY FIX 4: Show loading while router is initializing OR data is loading
+  if (!router.isReady || loading || !shouldFetch) {
     return (
       <Layout>
         <LoadingScreen />
@@ -154,13 +179,41 @@ export default function ChangeBookingPage() {
     );
   }
 
-  if (error) {
+  // KEY FIX 5: Show error state properly
+  if (error || queryError) {
     return (
       <Layout>
         <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
-          <p className="text-red-500">
-            {error ? "Error loading booking." : "Booking not found."}
-          </p>
+          <div className="text-center">
+            <p className="text-red-500 text-xl mb-4">
+              {error || "Error loading booking."}
+            </p>
+            <button
+              onClick={() => router.push("/customer/booking-history")}
+              className="px-6 py-2 bg-orange-600 text-white rounded hover:bg-orange-700"
+            >
+              Back to Booking History
+            </button>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  // KEY FIX 6: Show not found state
+  if (!booking) {
+    return (
+      <Layout>
+        <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-gray-600 text-xl mb-4">Booking not found.</p>
+            <button
+              onClick={() => router.push("/customer/booking-history")}
+              className="px-6 py-2 bg-orange-600 text-white rounded hover:bg-orange-700"
+            >
+              Back to Booking History
+            </button>
+          </div>
         </div>
       </Layout>
     );
@@ -217,14 +270,12 @@ export default function ChangeBookingPage() {
               {/* Booking Details Section */}
               <div className="md:w-full">
                 {/* Original Booking Detail Component */}
-                {booking && (
-                  <OriginalBookingDetail
-                    roomType={booking?.rooms?.room_type}
-                    bookingDate={booking?.booking_date}
-                    checkInDate={booking?.check_in_date}
-                    checkOutDate={booking?.check_out_date}
-                  />
-                )}
+                <OriginalBookingDetail
+                  roomType={booking?.rooms?.room_type}
+                  bookingDate={booking?.booking_date}
+                  checkInDate={booking?.check_in_date}
+                  checkOutDate={booking?.check_out_date}
+                />
 
                 {/* Validation Error Message */}
                 {validationError && (
@@ -265,6 +316,7 @@ export default function ChangeBookingPage() {
                     onSubmit={handleSubmit}
                     onClick={handleOpenModal}
                     onCancel={handleCancel}
+                    minDate={today} // 👈 THIS WAS ADDED - Pass today's date
                   />
                 </div>
               </div>

--- a/src/pages/customer/customer-bookings/change/[bookingId].tsx
+++ b/src/pages/customer/customer-bookings/change/[bookingId].tsx
@@ -1,0 +1,227 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import Layout from "@/components/Layout";
+import Image from "next/image";
+
+interface Booking {
+  id: string;
+  checkIn: string;
+  checkOut: string;
+  roomType: string;
+  roomImage: string;
+  bookingDate: string;
+}
+
+export default function ChangeBookingPage() {
+  const router = useRouter();
+  const { bookingId } = router.query;
+  const [booking, setBooking] = useState<Booking | null>(null);
+  const [checkIn, setCheckIn] = useState("");
+  const [checkOut, setCheckOut] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!bookingId) return;
+
+    const fetchBooking = async () => {
+      setLoading(true);
+
+      // Mock booking data - replace with actual API call
+      const mockBooking: Booking = {
+        id: bookingId as string,
+        checkIn: "2022-10-19",
+        checkOut: "2022-10-20",
+        roomType: "Superior Garden View",
+        roomImage: "/images/garden-view.jpg", // Replace with actual image
+        bookingDate: "Tue, 18 Oct 2022",
+      };
+
+      setBooking(mockBooking);
+      setCheckIn(mockBooking.checkIn);
+      setCheckOut(mockBooking.checkOut);
+      setLoading(false);
+    };
+
+    fetchBooking();
+  }, [bookingId]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!booking) return;
+
+    console.log("Updating booking:", {
+      id: booking.id,
+      checkIn,
+      checkOut,
+    });
+
+    alert("Booking updated successfully!");
+    router.push("/booking-history");
+  };
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  if (loading) {
+    return (
+      <Layout>
+        <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
+          <p className="text-gray-600">Loading booking details...</p>
+        </div>
+      </Layout>
+    );
+  }
+
+  if (!booking) {
+    return (
+      <Layout>
+        <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
+          <p className="text-red-500">Booking not found.</p>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="min-h-screen bg-[#F7F7FB]">
+        <div className="min-w-screen md:px-20 pt-25">
+          {/* Header */}
+          <h1 className="text-6xl md:text-7xl text-green-700 mb-5 md:mb-12 font-noto font-medium px-5 ">
+            <span>Change </span>
+            <br className="md:hidden" />
+            <span>Check-in </span>
+            <br className="hidden md:block" />
+            <span>and Check-out Date</span>
+          </h1>
+
+          {/* Booking Card */}
+          <div className="bg-[#F7F7FB] md:mt-30">
+            <div className="flex flex-col md:flex-row">
+              {/* Room Image */}
+              <div>
+                {/* Room Image */}
+                <div className="w-full md:w-[370px] h-50 md:h-[200px] relative md:rounded-md overflow-hidden">
+                  <Image
+                    src="https://images.unsplash.com/photo-1566073771259-6a8506099945"
+                    alt="room-image"
+                    fill
+                    className="block object-cover"
+                  />
+                </div>
+
+                {/* Cancel Button */}
+                <div className="flex h-full">
+                  <button
+                    type="button"
+                    onClick={handleCancel}
+                    className="hidden md:block px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+
+              {/* Booking Details */}
+              <div className="md:w-full p-5 md:pl-15">
+                <div className="flex flex-col md:flex-row justify-between items-start mb-6">
+                  <h2 className="text-3xl md:text-4xl font-bold text-black font-inter mt-2">
+                    {booking.roomType}
+                  </h2>
+                  <p className="text-md text-gray-600">
+                    Booking date: {booking.bookingDate}
+                  </p>
+                </div>
+
+                {/* Original Dates */}
+                <div className="mb-8">
+                  <p className="text-lg font-semibold text-gray-800 mb-2">
+                    Original Date
+                  </p>
+                  <p className="text-gray-700 text-md">
+                    {new Date(booking.checkIn).toLocaleDateString("en-US", {
+                      weekday: "short",
+                      day: "numeric",
+                      month: "short",
+                      year: "numeric",
+                    })}{" "}
+                    -{" "}
+                    {new Date(booking.checkOut).toLocaleDateString("en-US", {
+                      weekday: "short",
+                      day: "numeric",
+                      month: "short",
+                      year: "numeric",
+                    })}
+                  </p>
+                </div>
+
+                {/* Change Date Form */}
+                <form
+                  onSubmit={handleSubmit}
+                  className="bg-white px-5 pt-5 pb-2 rounded-lg"
+                >
+                  <p className="text-lg font-bold text-gray-800 mb-4">
+                    Change Date
+                  </p>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+                    {/* Check In */}
+                    <div>
+                      <label className="block text-lg text-gray-800 mb-2">
+                        Check In
+                      </label>
+                      <div className="relative">
+                        <input
+                          type="date"
+                          value={checkIn}
+                          onChange={(e) => setCheckIn(e.target.value)}
+                          className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                          required
+                        />
+                      </div>
+                    </div>
+
+                    {/* Check Out */}
+                    <div>
+                      <label className="block text-lg text-gray-800 mb-2">
+                        Check Out
+                      </label>
+                      <div className="relative">
+                        <input
+                          type="date"
+                          value={checkOut}
+                          onChange={(e) => setCheckOut(e.target.value)}
+                          className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                          required
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </form>
+                {/* Confirm change date button */}
+                <div className="flex justify-end mt-10">
+                  <button
+                    type="submit"
+                    className="flex-1 md:flex-none px-8 py-3 bg-orange-600 hover:bg-orange-700 text-white font-medium rounded-md transition-colors"
+                  >
+                    Confirm Change Date
+                  </button>
+                </div>
+                <div className="flex h-full justify-center items-center mt-3">
+                  <button
+                    type="button"
+                    onClick={handleCancel}
+                    className="md:hidden px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/src/pages/customer/customer-bookings/change/[bookingId].tsx
+++ b/src/pages/customer/customer-bookings/change/[bookingId].tsx
@@ -78,9 +78,7 @@ export default function ChangeBookingPage() {
         setValidationError(
           `Number of nights must match the original booking (${originalNights} ${
             originalNights === 1 ? "night" : "nights"
-          }). Currently selected: ${newNights} ${
-            newNights === 1 ? "night" : "nights"
-          }.`
+          }).`
         );
       } else {
         setValidationError("");

--- a/src/pages/customer/customer-bookings/change/[bookingId].tsx
+++ b/src/pages/customer/customer-bookings/change/[bookingId].tsx
@@ -2,68 +2,98 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import Layout from "@/components/Layout";
 import Image from "next/image";
+import { useQuery } from "@/hooks/useQuery";
+import { formatDate } from "@/utils/formatDate";
 
-interface Booking {
-  id: string;
-  checkIn: string;
-  checkOut: string;
-  roomType: string;
-  roomImage: string;
-  bookingDate: string;
-}
-
+import ChangeDateForm from "@/components/booking/changeDateForm";
 export default function ChangeBookingPage() {
   const router = useRouter();
   const { bookingId } = router.query;
-  const [booking, setBooking] = useState<Booking | null>(null);
   const [checkIn, setCheckIn] = useState("");
   const [checkOut, setCheckOut] = useState("");
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
 
+  interface RoomforBookings {
+    guests: number;
+    bed_type: string;
+    room_type: string;
+    main_image_url: string[];
+  }
+
+  interface Booking {
+    id: string;
+    user_id: string;
+    room_id: string;
+    customer_id: string;
+    status: "pending" | "confirmed" | "cancelled" | "refunded";
+    booking_date: string;
+    payment_method: string;
+    check_in_date: string;
+    check_out_date: string;
+    total_amount: number;
+    special_requests?: string[];
+    additional_request?: string[];
+    standard_request?: string[];
+    created_at: string;
+    rooms?: RoomforBookings | undefined;
+  }
+
+  type BookingApiResponse = {
+    success: boolean;
+    message: string;
+    data?: Booking | null;
+    error?: string;
+  };
+
+  // Fetch booking data using useQuery
+  const { data: bookingResponse } = useQuery<BookingApiResponse>(
+    `/api/bookings/${bookingId}`
+  );
+
+  const booking = bookingResponse?.data;
+
+  // Update form fields when booking data is loaded
   useEffect(() => {
-    if (!bookingId) return;
-
-    const fetchBooking = async () => {
-      setLoading(true);
-
-      // Mock booking data - replace with actual API call
-      const mockBooking: Booking = {
-        id: bookingId as string,
-        checkIn: "2022-10-19",
-        checkOut: "2022-10-20",
-        roomType: "Superior Garden View",
-        roomImage: "/images/garden-view.jpg", // Replace with actual image
-        bookingDate: "Tue, 18 Oct 2022",
-      };
-
-      setBooking(mockBooking);
-      setCheckIn(mockBooking.checkIn);
-      setCheckOut(mockBooking.checkOut);
-      setLoading(false);
-    };
-
-    fetchBooking();
-  }, [bookingId]);
+    if (booking) {
+      setCheckIn(booking.check_in_date);
+      setCheckOut(booking.check_out_date);
+    }
+  }, [booking]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!booking) return;
 
-    console.log("Updating booking:", {
-      id: booking.id,
-      checkIn,
-      checkOut,
-    });
+    try {
+      const response = await fetch(`/api/bookings/${booking.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          check_in_date: checkIn,
+          check_out_date: checkOut,
+        }),
+      });
 
-    alert("Booking updated successfully!");
-    router.push("/booking-history");
+      if (!response.ok) {
+        throw new Error("Failed to update booking");
+      }
+
+      alert("Booking updated successfully!");
+      router.push("/booking-history");
+    } catch (error) {
+      console.error("Error updating booking:", error);
+      alert("Failed to update booking. Please try again.");
+    }
   };
 
   const handleCancel = () => {
     router.back();
   };
 
-  if (loading) {
+  if (isLoading) {
     return (
       <Layout>
         <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
@@ -73,11 +103,13 @@ export default function ChangeBookingPage() {
     );
   }
 
-  if (!booking) {
+  if (error || !booking) {
     return (
       <Layout>
         <div className="min-h-screen bg-[#F7F7FB] flex items-center justify-center">
-          <p className="text-red-500">Booking not found.</p>
+          <p className="text-red-500">
+            {error ? "Error loading booking." : "Booking not found."}
+          </p>
         </div>
       </Layout>
     );
@@ -104,14 +136,17 @@ export default function ChangeBookingPage() {
                 {/* Room Image */}
                 <div className="w-full md:w-[370px] h-50 md:h-[200px] relative md:rounded-md overflow-hidden">
                   <Image
-                    src="https://images.unsplash.com/photo-1566073771259-6a8506099945"
-                    alt="room-image"
+                    src={
+                      booking.rooms?.main_image_url[0] ||
+                      "https://images.unsplash.com/photo-1566073771259-6a8506099945"
+                    }
+                    alt={booking.rooms?.room_type || "room-image"}
                     fill
                     className="block object-cover"
                   />
                 </div>
 
-                {/* Cancel Button */}
+                {/* Desktop Cancel Button */}
                 <div className="flex h-full">
                   <button
                     type="button"
@@ -124,13 +159,16 @@ export default function ChangeBookingPage() {
               </div>
 
               {/* Booking Details */}
-              <div className="md:w-full p-5 md:pl-15">
+              <div className="md:w-full p-5 md:p-0 md:pl-15">
                 <div className="flex flex-col md:flex-row justify-between items-start mb-6">
                   <h2 className="text-3xl md:text-4xl font-bold text-black font-inter mt-2">
-                    {booking.roomType}
+                    {booking.rooms?.room_type}
                   </h2>
                   <p className="text-md text-gray-600">
-                    Booking date: {booking.bookingDate}
+                    Booking date:{" "}
+                    {booking?.booking_date
+                      ? formatDate(booking.booking_date)
+                      : "N/A"}
                   </p>
                 </div>
 
@@ -140,83 +178,20 @@ export default function ChangeBookingPage() {
                     Original Date
                   </p>
                   <p className="text-gray-700 text-md">
-                    {new Date(booking.checkIn).toLocaleDateString("en-US", {
-                      weekday: "short",
-                      day: "numeric",
-                      month: "short",
-                      year: "numeric",
-                    })}{" "}
-                    -{" "}
-                    {new Date(booking.checkOut).toLocaleDateString("en-US", {
-                      weekday: "short",
-                      day: "numeric",
-                      month: "short",
-                      year: "numeric",
-                    })}
+                    {formatDate(booking.check_in_date)} -{" "}
+                    {formatDate(booking.check_out_date)}
                   </p>
                 </div>
 
-                {/* Change Date Form */}
-                <form
+                {/* Change Date Form Component */}
+                <ChangeDateForm
+                  checkIn={checkIn}
+                  checkOut={checkOut}
+                  onCheckInChange={setCheckIn}
+                  onCheckOutChange={setCheckOut}
                   onSubmit={handleSubmit}
-                  className="bg-white px-5 pt-5 pb-2 rounded-lg"
-                >
-                  <p className="text-lg font-bold text-gray-800 mb-4">
-                    Change Date
-                  </p>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-                    {/* Check In */}
-                    <div>
-                      <label className="block text-lg text-gray-800 mb-2">
-                        Check In
-                      </label>
-                      <div className="relative">
-                        <input
-                          type="date"
-                          value={checkIn}
-                          onChange={(e) => setCheckIn(e.target.value)}
-                          className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-                          required
-                        />
-                      </div>
-                    </div>
-
-                    {/* Check Out */}
-                    <div>
-                      <label className="block text-lg text-gray-800 mb-2">
-                        Check Out
-                      </label>
-                      <div className="relative">
-                        <input
-                          type="date"
-                          value={checkOut}
-                          onChange={(e) => setCheckOut(e.target.value)}
-                          className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-                          required
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </form>
-                {/* Confirm change date button */}
-                <div className="flex justify-end mt-10">
-                  <button
-                    type="submit"
-                    className="flex-1 md:flex-none px-8 py-3 bg-orange-600 hover:bg-orange-700 text-white font-medium rounded-md transition-colors"
-                  >
-                    Confirm Change Date
-                  </button>
-                </div>
-                <div className="flex h-full justify-center items-center mt-3">
-                  <button
-                    type="button"
-                    onClick={handleCancel}
-                    className="md:hidden px-6 py-3 text-orange-600 hover:text-orange-700 font-medium transition-colors"
-                  >
-                    Cancel
-                  </button>
-                </div>
+                  onCancel={handleCancel}
+                />
               </div>
             </div>
           </div>

--- a/src/pages/customer/customer-bookings/change/[bookingId].tsx
+++ b/src/pages/customer/customer-bookings/change/[bookingId].tsx
@@ -272,7 +272,7 @@ export default function ChangeBookingPage() {
                 {/* Original Booking Detail Component */}
                 <OriginalBookingDetail
                   roomType={booking?.rooms?.room_type}
-                  bookingDate={booking?.booking_date}
+                  bookingDate={booking?.created_at}
                   checkInDate={booking?.check_in_date}
                   checkOutDate={booking?.check_out_date}
                 />

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,60 @@
+/**
+ * Calculate the number of nights between two dates
+ * @param checkInDate - Check-in date string (ISO format or any valid date string)
+ * @param checkOutDate - Check-out date string (ISO format or any valid date string)
+ * @returns Number of nights between the two dates
+ */
+export const calculateNights = (
+  checkInDate: string,
+  checkOutDate: string
+): number => {
+  const checkIn = new Date(checkInDate);
+  const checkOut = new Date(checkOutDate);
+  const diffTime = checkOut.getTime() - checkIn.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  return diffDays;
+};
+
+/**
+ * Format a date string to a readable format
+ * @param dateString - Date string to format
+ * @param locale - Locale for formatting (default: 'en-US')
+ * @returns Formatted date string
+ */
+export const formatDate = (
+  dateString: string,
+  locale: string = "en-US"
+): string => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString(locale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};
+
+/**
+ * Check if a date is valid
+ * @param dateString - Date string to validate
+ * @returns True if date is valid, false otherwise
+ */
+export const isValidDate = (dateString: string): boolean => {
+  const date = new Date(dateString);
+  return !isNaN(date.getTime());
+};
+
+/**
+ * Get date range info
+ * @param checkInDate - Check-in date string
+ * @param checkOutDate - Check-out date string
+ * @returns Object containing nights count and formatted date strings
+ */
+export const getDateRangeInfo = (checkInDate: string, checkOutDate: string) => {
+  const nights = calculateNights(checkInDate, checkOutDate);
+  return {
+    nights,
+    checkIn: formatDate(checkInDate),
+    checkOut: formatDate(checkOutDate),
+    nightsText: `${nights} ${nights === 1 ? "night" : "nights"}`,
+  };
+};

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,14 @@
+// utils/formatDate.ts
+
+export function formatDate(dateString: string): string {
+  if (!dateString) return "";
+
+  return new Date(dateString)
+    .toLocaleDateString("en-GB", {
+      weekday: "short",
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    })
+    .replace(/,/g, "");
+}


### PR DESCRIPTION
## Changes 

### UI
- Add ChangeBookingDate Page, CancelBooking Page, RefundRequestPage, CancelSuccess Page, RefundSubmitted Page
- Add mobile responsiveness for all pages
- Add Toaster on the main Layout

### Logic
- Validate input when changing check-in and check-out dates
- Update the booking status upon cancelling and requesting refund while adding the cancellation_date

### Paths
- Update Check-in & Check-out Dates
`/customer/customer-bookings/change/${bookingId}`

- Cancel (with no refund)
`/customer/customer-bookings/cancel/${bookingId}`

- Refund Request
`/customer/customer-bookings/cancel/${bookingId}/refund-request`

- Cancel Complete
`/customer/customer-bookings/cancel/${bookingId}/cancel-completed`

- Refund Requested Successful
`/customer/customer-bookings/cancel/${bookingId}/refund-submitted`
